### PR TITLE
fix(helm): route /api through nginx, set port 8080, whitelist public assets in oauth2-proxy

### DIFF
--- a/charts/nebari-landing/templates/frontend/configmap.yaml
+++ b/charts/nebari-landing/templates/frontend/configmap.yaml
@@ -18,4 +18,92 @@ data:
         "clientId": {{ .Values.frontend.keycloak.clientId | quote }}
       }
     }
+
+  # nginx configuration for the frontend pod.
+  #
+  # Traffic flow (production):
+  #   Browser → Gateway → frontend Service (oauth2-proxy:4180)
+  #     → oauth2-proxy validates session cookie, injects Authorization: Bearer <token>
+  #       → nginx (127.0.0.1:{{ .Values.frontend.port }})
+  #         ├─ /api/*  → proxy_pass to webapi ClusterIP (cluster DNS, never public)
+  #         └─ /*      → serve SPA index.html
+  #
+  # The webapi is never exposed through the Gateway.
+  nginx.conf: |
+    worker_processes auto;
+    pid /tmp/nginx.pid;
+
+    events {
+        worker_connections 1024;
+    }
+
+    http {
+        include       /etc/nginx/mime.types;
+        default_type  application/octet-stream;
+
+        client_body_temp_path /tmp/client_temp;
+        proxy_temp_path       /tmp/proxy_temp_path;
+        fastcgi_temp_path     /tmp/fastcgi_temp;
+        uwsgi_temp_path       /tmp/uwsgi_temp;
+        scgi_temp_path        /tmp/scgi_temp;
+
+        sendfile        on;
+        keepalive_timeout 65;
+
+        access_log /dev/stdout;
+        error_log  /dev/stderr warn;
+
+        # WebSocket upgrade map (required for /api/v1/ws)
+        map $http_upgrade $connection_upgrade {
+            default   upgrade;
+            ''        close;
+        }
+
+        server {
+            listen {{ .Values.frontend.port }};
+            server_name _;
+
+            root /usr/share/nginx/html;
+            index index.html;
+
+            gzip on;
+            gzip_types text/plain text/css application/json application/javascript
+                       text/xml application/xml application/xml+rss text/javascript
+                       image/svg+xml;
+            gzip_min_length 1024;
+
+            # Proxy /api/* to the webapi ClusterIP — never exposed publicly.
+            location /api/ {
+                proxy_pass         http://{{ include "nebari-landing.fullname" . }}-webapi.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.webapi.service.port }}/api/;
+                proxy_set_header   Authorization      $http_authorization;
+                proxy_set_header   X-Real-IP          $remote_addr;
+                proxy_set_header   X-Forwarded-For    $proxy_add_x_forwarded_for;
+                proxy_set_header   Host               $host;
+                proxy_http_version 1.1;
+                proxy_set_header   Upgrade            $http_upgrade;
+                proxy_set_header   Connection         $connection_upgrade;
+                proxy_read_timeout 3600s;
+                proxy_send_timeout 3600s;
+            }
+
+            # Cache static assets aggressively (Vite outputs content-hashed filenames)
+            location ~* \.(js|css|png|svg|ico|woff2?|ttf|eot)$ {
+                expires 1y;
+                add_header Cache-Control "public, immutable";
+                try_files $uri =404;
+            }
+
+            # Health check
+            location /healthz {
+                access_log off;
+                return 200 "ok\n";
+                add_header Content-Type text/plain;
+            }
+
+            # SPA fallback
+            location / {
+                try_files $uri $uri/ /index.html;
+            }
+        }
+    }
 {{- end }}

--- a/charts/nebari-landing/templates/frontend/deployment.yaml
+++ b/charts/nebari-landing/templates/frontend/deployment.yaml
@@ -151,6 +151,12 @@ spec:
               mountPath: /var/cache/nginx
             - name: nginx-run
               mountPath: /var/run
+            # Helm-rendered nginx.conf — includes /api/ proxy_pass to the webapi
+            # ClusterIP so the browser never reaches the webapi directly.
+            - name: frontend-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+              readOnly: true
             # Mounts the Helm-rendered config.json from the ConfigMap, overriding
             # the placeholder baked into the image at build time.
             - name: frontend-config

--- a/charts/nebari-landing/values.yaml
+++ b/charts/nebari-landing/values.yaml
@@ -21,7 +21,9 @@ frontend:
 
   # Port the static file server listens on *inside the pod* (reachable only
   # via the OAuth2 Proxy sidecar; not exposed externally).
-  port: 80
+  # Must be > 1024 — the nginx container runs as non-root (UID 101) with all
+  # capabilities dropped and cannot bind privileged ports.
+  port: 8080
 
   # Keycloak connection settings — rendered into /config.json at deploy time
   # by the frontend ConfigMap. The frontend fetches this file at startup so
@@ -75,6 +77,11 @@ frontend:
     # (e.g. the public landing page). Regex is matched against the full path.
     extraArgs:
       - --skip-auth-route=^/public
+      # Static assets must bypass auth so the browser can load JS/CSS chunks
+      # for public routes without being redirected to Keycloak login.
+      - --skip-auth-route=^/assets/
+      - --skip-auth-route=^/favicon
+      - --skip-auth-route=^/config\.json$
     # - --skip-provider-button
 
     # Init container that blocks oauth2-proxy from starting until Keycloak's


### PR DESCRIPTION
## Problem

Three related issues prevented the frontend from working correctly in a deployed cluster:

1. **nginx port 80 crash-loop**: The nginx container runs as non-root (UID 101) with all Linux capabilities dropped. Port 80 is privileged — nginx exited immediately on startup and oauth2-proxy returned 502 to every browser request.

2. **No /api/ proxy in nginx**: nginx only served static files. Browser API calls at relative `/api/v1/…` hit nginx and got 404 instead of being forwarded to the webapi pod.

3. **oauth2-proxy intercepted static asset fetches for the public page**: `/public` was whitelisted, so the HTML loaded. But the browser's follow-up fetches for the lazy-loaded JS/CSS chunks (`/assets/PublicPage-*.{js,css}`) were not whitelisted. oauth2-proxy redirected them to Keycloak login (which responds from `localhost:8180`), causing a CORS block.

## Changes

### `charts/nebari-landing/templates/frontend/configmap.yaml`
Added `nginx.conf` key with a complete server block:
- `location /api/` proxy_passes to the webapi ClusterIP (cluster-internal DNS, never reachable from outside the cluster)
- Forwards `Authorization`, `Upgrade`, and `Connection` headers so Bearer tokens and WebSocket connections work end-to-end
- Standard SPA fallback and static asset caching rules

### `charts/nebari-landing/templates/frontend/deployment.yaml`
Mounts the Helm-rendered `nginx.conf` at `/etc/nginx/nginx.conf` via a subPath volume mount, replacing the image-baked default.

### `charts/nebari-landing/values.yaml`
- `frontend.port`: `80` → `8080` (non-root safe)
- `oauth2Proxy.extraArgs`: added `--skip-auth-route` for `^/assets/`, `^/favicon`, and `^/config\.json$`
