### PR TITLE
fix(frontend): unwrap wrapped webapi list responses

### DIFF
--- a/frontend/src/api/listNnotifications.ts
+++ b/frontend/src/api/listNnotifications.ts
@@ -19,5 +19,7 @@ export async function listNotifications(): Promise<Notification[]> {
     throw new Error(`Response: ${resp.status} ${resp.statusText}`);
   }
 
-  return resp.json();
+  // webapi wraps the array: { "notifications": [...] }
+  const json = await resp.json();
+  return Array.isArray(json) ? json : (json.notifications ?? []);
 }

--- a/frontend/src/api/listServices.ts
+++ b/frontend/src/api/listServices.ts
@@ -23,5 +23,7 @@ export async function listServices(): Promise<Service[]> {
     throw new Error(`Response: ${resp.status} ${resp.statusText}`);
   }
 
-  return resp.json();
+  // webapi wraps the array: { "services": [...] }
+  const json = await resp.json();
+  return Array.isArray(json) ? json : (json.services ?? []);
 }

--- a/frontend/src/app/index.tsx
+++ b/frontend/src/app/index.tsx
@@ -22,9 +22,7 @@ export default function App() {
       .catch((err) => {
         console.error("listServices failed", err);
       });
-  })
-
-  console.log(services)
+  }, [])
 
   return (
     <div className={isDarkMode ? "app-shell app-shell--dark" : "app-shell app-shell--light"}>
@@ -33,7 +31,7 @@ export default function App() {
         onToggleTheme={() => setIsDarkMode((prev) => !prev)}
         user={user}
       />
-      <Content />
+      <Content services={services} />
     </div>
   );
 }

--- a/frontend/src/components/content/index.tsx
+++ b/frontend/src/components/content/index.tsx
@@ -1,68 +1,74 @@
 import type { ReactNode } from "react";
 
 import AppAccordion from "../accordion";
+import type { Service } from "../../api/listServices";
 
 import "./index.scss";
 
-export default function Content(): ReactNode {
-  const services = [
-    {
-      id: "svc-1",
-      image: "",
-      name: "Payments",
-      status: "Healthy",
-      description: "Process transactions and manage payment flows.",
-      category: ["Finance", "Core"],
-      pinned: true,
-    },
-    {
-      id: "svc-2",
-      image: "",
-      name: "Notifications",
-      status: "Active",
-      description: "Send email, SMS, and in-app notifications.",
-      category: ["Messaging", "Platform"],
-      pinned: false,
-    },
-    {
-      id: "svc-3",
-      image: "",
-      name: "User Directory",
-      status: "Healthy",
-      description: "Manage users, groups, and directory sync.",
-      category: ["Identity", "Admin"],
-      pinned: true,
-    },
-    {
-      id: "svc-4",
-      image: "",
-      name: "Analytics",
-      status: "Degraded",
-      description: "Dashboards and usage metrics for services.",
-      category: ["Reporting", "Insights"],
-      pinned: false,
-    },
-    {
-      id: "svc-5",
-      image: "",
-      name: "Audit Logs",
-      status: "Healthy",
-      description: "Track system events and user activity history.",
-      category: ["Security", "Compliance"],
-      pinned: false,
-    },
-    {
-      id: "svc-6",
-      image: "",
-      name: "Developer Portal",
-      status: "Active",
-      description: "Docs, API keys, and developer tooling.",
-      category: ["Developer", "Platform"],
-      pinned: false,
-    },
-  ];
+const MOCK_SERVICES: Service[] = [
+  {
+    id: "svc-1",
+    image: "",
+    name: "Payments",
+    status: "Healthy",
+    description: "Process transactions and manage payment flows.",
+    category: ["Finance", "Core"],
+    pinned: true,
+  },
+  {
+    id: "svc-2",
+    image: "",
+    name: "Notifications",
+    status: "Active",
+    description: "Send email, SMS, and in-app notifications.",
+    category: ["Messaging", "Platform"],
+    pinned: false,
+  },
+  {
+    id: "svc-3",
+    image: "",
+    name: "User Directory",
+    status: "Healthy",
+    description: "Manage users, groups, and directory sync.",
+    category: ["Identity", "Admin"],
+    pinned: true,
+  },
+  {
+    id: "svc-4",
+    image: "",
+    name: "Analytics",
+    status: "Degraded",
+    description: "Dashboards and usage metrics for services.",
+    category: ["Reporting", "Insights"],
+    pinned: false,
+  },
+  {
+    id: "svc-5",
+    image: "",
+    name: "Audit Logs",
+    status: "Healthy",
+    description: "Track system events and user activity history.",
+    category: ["Security", "Compliance"],
+    pinned: false,
+  },
+  {
+    id: "svc-6",
+    image: "",
+    name: "Developer Portal",
+    status: "Active",
+    description: "Docs, API keys, and developer tooling.",
+    category: ["Developer", "Platform"],
+    pinned: false,
+  },
+];
 
-  const pinnedServices = services.filter((service) => service.pinned);
+type ContentProps = {
+  services?: Service[] | null;
+};
+
+export default function Content({ services }: ContentProps): ReactNode {
+  const serviceList = services ?? MOCK_SERVICES;
+  const pinnedServices = serviceList.filter((service) => service.pinned);
 
   return (
     <main id="main-content" className="app-content">
@@ -70,7 +76,7 @@ export default function Content(): ReactNode {
 
       <AppAccordion
         pinnedServices={pinnedServices}
-        services={services}
+        services={serviceList}
       />
     </main>
   );


### PR DESCRIPTION
## Problem

The webapi wraps list responses in a top-level key:

```
GET /api/v1/services       -> { "services": [...] }
GET /api/v1/notifications  -> { "notifications": [...] }
```

`listServices()` and `listNotifications()` were returning `resp.json()` directly. Consumers then called `.filter()` on a plain object, producing:

```
Uncaught TypeError: a.filter is not a function
```

A secondary issue after we fixes the CORS issues was the temporary usage of : `useEffect` in `App` was missing the `[]` dependency array, causing `listServices()` to fire on every render (infinite request loop).

## Changes

### `frontend/src/api/listServices.ts`
Unwrap response: `const json = await resp.json(); return Array.isArray(json) ? json : (json.services ?? []);`

### `frontend/src/api/listNnotifications.ts`
Unwrap response: `return Array.isArray(json) ? json : (json.notifications ?? []);`

### `frontend/src/app/index.tsx`
- Add `[]` dependency array to `useEffect` — fetch runs once on mount only
- Thread the `services` state down to `<Content services={services} />`

### `frontend/src/components/content/index.tsx`
- Accept `services?: Service[] | null` prop
- Fall back to `MOCK_SERVICES` when `null` so the page renders immediately before the first fetch resolves
