### PR TITLE
fix(dev): dev-watch port 8080, Vite /api proxy, Makefile image reload

### DIFF
--- a/dev/Makefile
+++ b/dev/Makefile
@@ -170,14 +170,36 @@ cluster-delete:
 # ── Image build & load ────────────────────────────────────────────────────────
 
 ## image-build: build webapi and frontend images and load them into minikube
+# _minikube-reload: evict pods, remove stale image, load fresh one, restore replicas.
+# $(1) = deployment name suffix (e.g. webapi, frontend)
+# $(2) = pod label selector (e.g. app.kubernetes.io/component=webapi)
+# $(3) = image ref (e.g. $(WEBAPI_IMAGE))
+define _minikube-reload
+	@REPLICAS=$$(kubectl get deploy $(HELM_RELEASE)-$(1) -n $(NAMESPACE_APP) \
+	  -o jsonpath='{.spec.replicas}' 2>/dev/null || echo 0); \
+	if [ "$$REPLICAS" -gt 0 ] 2>/dev/null; then \
+	  echo "→  Scaling $(HELM_RELEASE)-$(1) to 0 to release the stale image …"; \
+	  kubectl scale deployment $(HELM_RELEASE)-$(1) -n $(NAMESPACE_APP) --replicas=0; \
+	  kubectl wait --for=delete pod -l $(2) -n $(NAMESPACE_APP) --timeout=60s 2>/dev/null || true; \
+	fi; \
+	echo "→  Removing old $(3) from minikube (if present) …"; \
+	$(MINIKUBE_BIN) -p $(CLUSTER_NAME) image rm $(3) 2>/dev/null || true; \
+	echo "→  Loading $(3) into minikube …"; \
+	$(MINIKUBE_BIN) -p $(CLUSTER_NAME) image load $(3); \
+	if [ "$$REPLICAS" -gt 0 ] 2>/dev/null; then \
+	  echo "→  Restoring $(HELM_RELEASE)-$(1) to $$REPLICAS replica(s) …"; \
+	  kubectl scale deployment $(HELM_RELEASE)-$(1) -n $(NAMESPACE_APP) --replicas=$$REPLICAS; \
+	fi
+endef
+
 image-build:
 	@echo "→  Building webapi image $(WEBAPI_IMAGE) …"
 	docker build -t $(WEBAPI_IMAGE) -f Dockerfile .
-	$(MINIKUBE_BIN) -p $(CLUSTER_NAME) image load $(WEBAPI_IMAGE)
+	$(call _minikube-reload,webapi,app.kubernetes.io/component=webapi,$(WEBAPI_IMAGE))
 	@echo "→  Building frontend image $(FRONTEND_IMAGE) …"
 	# Build context is frontend/ — Dockerfile lives there and only touches that tree.
 	docker build -t $(FRONTEND_IMAGE) -f frontend/Dockerfile frontend/
-	$(MINIKUBE_BIN) -p $(CLUSTER_NAME) image load $(FRONTEND_IMAGE)
+	$(call _minikube-reload,frontend,app.kubernetes.io/component=frontend,$(FRONTEND_IMAGE))
 	@echo "✔  Images loaded into minikube: $(WEBAPI_IMAGE) $(FRONTEND_IMAGE)"
 
 # ── cert-manager ───────────────────────────────────────────────────────────────────
@@ -374,6 +396,12 @@ install:
 	  --namespace $(NAMESPACE_APP) \
 	  --values dev/chart-values.yaml \
 	  --wait --timeout 5m
+	# Force pods to restart so pullPolicy:Never always picks up the freshly loaded :dev image.
+	# This is a no-op on first install (pods already started above) but essential on re-runs.
+	-kubectl rollout restart deployment/$(HELM_RELEASE)-webapi    -n $(NAMESPACE_APP) 2>/dev/null || true
+	-kubectl rollout restart deployment/$(HELM_RELEASE)-frontend  -n $(NAMESPACE_APP) 2>/dev/null || true
+	-kubectl rollout status  deployment/$(HELM_RELEASE)-webapi    -n $(NAMESPACE_APP) --timeout=2m 2>/dev/null || true
+	-kubectl rollout status  deployment/$(HELM_RELEASE)-frontend  -n $(NAMESPACE_APP) --timeout=2m 2>/dev/null || true
 	@echo "✔  nebari-landing deployed in namespace '$(NAMESPACE_APP)'"
 
 ## uninstall: remove deployed resources (does not delete the cluster)

--- a/dev/chart-values.yaml
+++ b/dev/chart-values.yaml
@@ -84,6 +84,20 @@ frontend:
       - --silence-ping-logging=true
       # Public routes — skip auth so unauthenticated users can access /public
       - --skip-auth-route=^/public
+      # Static assets must bypass auth so the browser can load JS/CSS chunks
+      # for public routes without being redirected to Keycloak login.
+      - --skip-auth-route=^/assets/
+      - --skip-auth-route=^/favicon
+      - --skip-auth-route=^/config\.json$
+      # Vite dev-server internal paths (dev-watch mode only).
+      # In production nginx serves pre-built bundles from /assets/ — these
+      # paths don't exist. In dev-watch Vite serves source files directly and
+      # oauth2-proxy would intercept them, breaking HMR and initial page load.
+      - --skip-auth-route=^/@vite/
+      - --skip-auth-route=^/@react-refresh
+      - --skip-auth-route=^/@fs/
+      - --skip-auth-route=^/src/
+      - --skip-auth-route=^/node_modules/
 
   # Expose via MetalLB LoadBalancer
   service:

--- a/dev/patches/frontend-dev-watch.yaml
+++ b/dev/patches/frontend-dev-watch.yaml
@@ -29,9 +29,9 @@
 #
 # 3. oauth2-proxy upstream port
 #    The upstream arg passed to oauth2-proxy in the chart is
-#    http://127.0.0.1:<frontend.port>. This patch keeps the same
-#    containerPort as the chart default (80), so no chart value needs to
-#    change. Vite is started with --port 80 to match.
+#    http://127.0.0.1:<frontend.port>. frontend.port is set to 8080 (non-root
+#    nginx cannot bind privileged ports). Vite is started with --port 8080 to
+#    match, and containerPort/probe ports are set to 8080 accordingly.
 
 spec:
   template:
@@ -77,11 +77,16 @@ spec:
           command:
             - sh
             - -c
-            - "npm install && exec npm run dev -- --host 0.0.0.0 --port 80 --force"
+            - "npm install && exec npm run dev -- --host 0.0.0.0 --port 8080 --force"
           workingDir: /app
           env:
             - name: VITE_USE_POLLING
               value: "true"
+            # Webapi ClusterIP — Vite proxies /api/ to this URL so the browser's
+            # relative API calls are forwarded server-side with the Authorization
+            # header that oauth2-proxy injects (mirrors what nginx does in prod).
+            - name: WEBAPI_URL
+              value: "http://nebari-landing-webapi.nebari-system.svc.cluster.local:8080"
             # oauth2-proxy injects large auth/cookie headers that exceed Node's
             # default 8 KB HTTP header buffer, causing Vite to respond 431.
             # Raise the limit to 64 KB.
@@ -91,19 +96,19 @@ spec:
             # frontend/public/config.json in dev mode — no VITE_* vars needed).
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 8080
           # Generous probes — npm install + Vite startup takes ~2-3 min.
           livenessProbe:
             httpGet:
               path: /
-              port: 80
+              port: 8080
             initialDelaySeconds: 180
             periodSeconds: 15
             failureThreshold: 6
           readinessProbe:
             httpGet:
               path: /
-              port: 80
+              port: 8080
             initialDelaySeconds: 90
             periodSeconds: 10
             failureThreshold: 12

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,18 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [react()],
   server: {
+    // When running in the dev-watch pod (VITE_USE_POLLING=true), Vite takes
+    // nginx's place. Proxy /api/ to the webapi ClusterIP so the browser's
+    // relative-URL API calls are forwarded server-side, with the Authorization
+    // header that oauth2-proxy injected preserved end-to-end.
+    proxy: process.env.VITE_USE_POLLING === "true" ? {
+      "/api": {
+        target: process.env.WEBAPI_URL ?? "http://nebari-landing-webapi.nebari-system.svc.cluster.local:8080",
+        changeOrigin: true,
+        // Forward WebSocket connections for the notifications hub.
+        ws: true,
+      },
+    } : undefined,
     // usePolling is required when the source directory is on a network-mounted
     // filesystem (9p via minikube mount, NFS, etc.) where inotify is not
     // supported.  The VITE_USE_POLLING env var lets us opt-in only inside the


### PR DESCRIPTION
## Problem

Four dev-workflow issues that only surface when using `make dev-watch` or `make image-build` iteratively:

1. **Port mismatch in dev-watch patch**: `frontend.port` was changed to 8080 in the Helm chart, but `frontend-dev-watch.yaml` still specified port 80. `kubectl patch` rejected the strategic merge with `Duplicate value: "http"` because the live Deployment already had `containerPort: 8080 name: http` and the patch tried to add a second entry `containerPort: 80 name: http`.

2. **No /api/ proxy in Vite dev server**: In dev-watch mode Vite replaces nginx inside the pod. Browser API calls at `/api/v1/…` hit Vite which had no proxy configured, so they returned 404. The webapi was unreachable.

3. **oauth2-proxy intercepted Vite's internal paths**: Vite serves source files as unbundled ES modules from `/@vite/client`, `/@react-refresh`, `/src/…`, etc. These paths were not on the oauth2-proxy skip list, so every browser fetch for a source file was redirected to Keycloak login (a different origin), producing a CORS block that broke page load and HMR.

4. **`minikube image load` does not replace a cached image**: Re-running `make image-build` after source changes loaded the new image tag but containerd kept serving the old layer — the pod restarted with the stale image. The only reliable fix is to scale the deployment to 0 (releasing the image reference), `minikube image rm`, load the fresh image, then restore replicas.

## Changes

### `dev/patches/frontend-dev-watch.yaml`
- All `containerPort`, probe `port`, and Vite `--port` values: `80` → `8080`
- Added `WEBAPI_URL` env var pointing to the webapi ClusterIP service

### `frontend/vite.config.ts`
Added `server.proxy` block gated on `VITE_USE_POLLING=true` (dev-watch pod only; no effect on normal local `npm run dev`):
- Proxies `/api/` → `WEBAPI_URL` (webapi ClusterIP)
- `changeOrigin: true` rewrites the Host header for cluster-internal routing
- `ws: true` forwards WebSocket connections for the notifications hub

### `dev/chart-values.yaml`
Added `--skip-auth-route` entries for Vite dev-server paths: `/@vite/`, `/@react-refresh`, `/@fs/`, `/src/`, `/node_modules/`. Also added the production asset routes (`/assets/`, `/favicon`, `/config.json`) so the dev override file is self-contained without depending on values.yaml defaults being merged.

### `dev/Makefile`
Added `_minikube-reload` macro used by `image-build`: scales the deployment to 0, removes the stale image from minikube's containerd, loads the fresh image, restores replicas. Added `kubectl rollout restart` + `rollout status` steps to the `install` target so re-running `make install` always picks up the latest locally built image.
