### PR TITLE
fix: frontend auth chain, 2-tier visibility model, debug endpoint

### DIFF
--- a/charts/nebari-landing/templates/webapi/deployment.yaml
+++ b/charts/nebari-landing/templates/webapi/deployment.yaml
@@ -80,6 +80,10 @@ spec:
             # setting matters only when using a Vite dev server with port-forward.
             - name: ALLOWED_ORIGINS
               value: {{ .Values.webapi.allowedOrigins | quote }}
+            # Debug mode — enables GET /api/v1/debug and verbose JWT logging.
+            # Set webapi.debugMode=true in values to activate. Never use in production.
+            - name: DEBUG_MODE
+              value: {{ .Values.webapi.debugMode | quote }}
             # Health
             - name: HEALTH_INTERVAL
               value: {{ .Values.webapi.healthInterval | quote }}

--- a/charts/nebari-landing/values.yaml
+++ b/charts/nebari-landing/values.yaml
@@ -33,7 +33,7 @@ frontend:
     # e.g. https://keycloak.example.com/auth
     url: ""
     realm: "nebari"
-    clientId: "nebari-landing"
+    clientId: "nebari-frontend-spa"
 
   resources:
     requests:
@@ -146,6 +146,13 @@ webapi:
   # the Vite dev server directly against a port-forwarded webapi, e.g.:
   #   allowedOrigins: "http://localhost:5173"
   allowedOrigins: "*"
+
+  # Enable the GET /api/v1/debug endpoint and verbose JWT logging.
+  # When true, the debug endpoint returns request headers (Bearer tokens redacted),
+  # resolved JWT claims, and per-visibility service counts — useful for diagnosing
+  # auth and proxy-forwarding problems in dev/staging.
+  # NEVER enable in production (it exposes internal auth state).
+  debugMode: false
 
   healthInterval: 30
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -56,6 +56,7 @@ func main() {
 		keycloakURL    string
 		keycloakRealm  string
 		enableAuth     bool
+		debugMode      bool
 		healthInterval int
 		adminGroup     string
 		redisAddr      string
@@ -88,6 +89,8 @@ func main() {
 		"Redis database index (env: REDIS_DB)")
 	flag.StringVar(&allowedOrigins, "allowed-origins", envStr("ALLOWED_ORIGINS", "*"),
 		"Comma-separated list of allowed CORS origins, or * for all (env: ALLOWED_ORIGINS)")
+	flag.BoolVar(&debugMode, "debug", envBool("DEBUG_MODE", false),
+		"Enable /api/v1/debug endpoint and verbose JWT logging. Never use in production (env: DEBUG_MODE)")
 
 	opts := zap.Options{
 		Development: true,
@@ -100,6 +103,7 @@ func main() {
 	setupLog.Info("Starting Nebari Landing Page API Server",
 		"port", port,
 		"authEnabled", enableAuth,
+		"debugMode", debugMode,
 		"healthInterval", healthInterval,
 		"allowedOrigins", allowedOrigins,
 	)
@@ -215,13 +219,19 @@ func main() {
 			"realm", os.Getenv("KEYCLOAK_REALM"))
 	}
 
-	handler := api.NewHandler(serviceCache, jwtValidator, enableAuth, hub, pinStore,
+	handlerOpts := []api.HandlerOption{
 		api.WithAccessRequestStore(accessRequestStore),
 		api.WithAdminGroup(adminGroup),
 		api.WithNotificationStore(notificationStore),
 		api.WithKeycloakAdminClient(keycloakAdminClient),
 		api.WithAllowedOrigins(splitOrigins(allowedOrigins)),
-	)
+	}
+	if debugMode {
+		setupLog.Info("Debug mode enabled — GET /api/v1/debug is active; do not use in production")
+		handlerOpts = append(handlerOpts, api.WithDebugMode())
+	}
+
+	handler := api.NewHandler(serviceCache, jwtValidator, enableAuth, hub, pinStore, handlerOpts...)
 
 	mux := handler.Routes()
 

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -15,17 +15,32 @@ RUN npm run build
 # ── Stage 2: serve ────────────────────────────────────────────────────────────
 FROM nginx:1.27-alpine AS runtime
 
+# envsubst is part of gettext — needed to render ${WEBAPI_URL} in the template.
+RUN apk add --no-cache gettext
+
 # Remove default nginx static assets
 RUN rm -rf /usr/share/nginx/html/*
 
 # Copy built assets from builder stage
 COPY --from=builder /app/dist /usr/share/nginx/html
 
-# Custom nginx config (main + server block) — non-root safe, all temps in /tmp
-COPY dev/nginx.conf /etc/nginx/nginx.conf
+# Copy the nginx config as a template — ${WEBAPI_URL} will be substituted at
+# container startup by envsubst, so the webapi address can be set via env var
+# without rebuilding the image.
+COPY dev/nginx.conf /etc/nginx/nginx.conf.template
+
+# Default webapi URL: the Helm-installed ClusterIP service in nebari-system.
+# Override with -e WEBAPI_URL=http://... when starting the container standalone.
+ENV WEBAPI_URL=http://nebari-landing-webapi.nebari-system.svc.cluster.local:8080
+
 EXPOSE 8080
 
 HEALTHCHECK --interval=15s --timeout=3s --start-period=5s --retries=3 \
   CMD wget -qO- http://localhost:8080/healthz || exit 1
 
-CMD ["nginx", "-g", "daemon off;"]
+# 1. Substitute ${WEBAPI_URL} in the template and write the final nginx.conf.
+#    Only ${WEBAPI_URL} is substituted — all other nginx $variable references
+#    (e.g. $remote_addr, $http_authorization) are left untouched.
+# 2. Start nginx in the foreground.
+CMD ["/bin/sh", "-c", \
+  "envsubst '${WEBAPI_URL}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"]

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -267,6 +267,7 @@ postgresql-secrets:
 	  --namespace $(NAMESPACE_KC) \
 	  --dry-run=client -o yaml | kubectl apply -f -
 	kubectl create secret generic nebari-realm-admin-credentials \
+	  --from-literal=username=admin \
 	  --from-literal=password=$(REALM_ADMIN_PASSWORD) \
 	  --namespace $(NAMESPACE_KC) \
 	  --dry-run=client -o yaml | kubectl apply -f -

--- a/dev/chart-values.yaml
+++ b/dev/chart-values.yaml
@@ -35,6 +35,16 @@ webapi:
     adminSecretName: "nebari-realm-admin-credentials"
     adminSecretNamespace: "keycloak"
 
+  # Set debugMode: true to activate GET /api/v1/debug and verbose JWT logging.
+  # Useful when authenticated services don't show up — the endpoint reveals
+  # whether the Authorization header reached the webapi and whether the JWT
+  # validated successfully.  Access via:
+  #   kubectl -n nebari-system port-forward svc/nebari-landing-webapi 8090:8080
+  #   curl http://localhost:8090/api/v1/debug        # unauthenticated view
+  #   curl -H "Authorization: Bearer <token>" http://localhost:8090/api/v1/debug
+  # Never enable in production.
+  debugMode: false
+
   # Expose via MetalLB so 'make port-forward' and direct LB access both work
   service:
     type: LoadBalancer
@@ -59,7 +69,7 @@ frontend:
     # Browser-visible Keycloak URL — exposed via port-forward at localhost:8180
     url: "http://localhost:8180/auth"
     realm: "nebari"
-    clientId: "nebari-landingpage"
+    clientId: "nebari-frontend-spa"
 
   oauth2Proxy:
     # Keycloak realm discovery endpoint — cluster-internal for the pod

--- a/dev/keycloak/frontend-client-job.yaml
+++ b/dev/keycloak/frontend-client-job.yaml
@@ -1,17 +1,20 @@
 ---
 # Dev fallback for NebariApp auth provisioning.
 #
-# In production, the nebari-operator reconciles spec.auth on the
-# 'nebari-landingpage' NebariApp and creates a Secret named
-# 'nebari-landingpage-oidc-client' (keys: client-id, client-secret).
+# Creates two Keycloak clients in the 'nebari' realm:
 #
-# In local dev the operator exits early at the TLS step (envoy-gateway-system
-# missing), so auth provisioning never runs. This Job creates the Keycloak
-# client using the same client-id the operator would use (NebariApp name).
-# The Makefile 'frontend-client' target then writes the matching k8s Secret.
+#   nebari-landingpage    — confidential client for the oauth2-proxy sidecar.
+#                           oauth2-proxy uses the code flow + client_secret to
+#                           exchange auth codes for tokens on the server side.
 #
-# Delete this job once the full operator stack (including envoy-gateway) is
-# available in the dev cluster.
+#   nebari-frontend-spa   — public client for keycloak-js PKCE in the browser.
+#                           The SPA authenticates directly with Keycloak (PKCE/S256)
+#                           and attaches the resulting Bearer token to every
+#                           /api/* request, so the webapi receives auth even in
+#                           dev without oauth2-proxy.
+#
+# In production the nebari-operator reconciles spec.auth on the 'nebari-landingpage'
+# NebariApp and creates the Secret; this Job fills that role for local dev.
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -35,137 +38,11 @@ spec:
                   key: admin-password
             - name: KEYCLOAK_URL
               value: http://keycloak-keycloakx-http.keycloak.svc.cluster.local/auth
-            # Static dev secret — safe only for local minikube.
-            # The operator generates a random secret; this value is written
-            # to the k8s Secret by the Makefile after this job completes.
+            # Static dev secret for the confidential oauth2-proxy client.
+            # Safe only for local minikube; the operator generates a random one in prod.
             - name: CLIENT_SECRET
               value: "nebari-frontend-dev-secret"
-            # MetalLB pinned IP for the landing page service
-            - name: LANDING_IP
-              value: "192.168.49.102"
-            # Localhost port used by 'make port-forward' — must match PORT_LANDING (default 8080).
-            - name: LOCALHOST_PORT
-              value: "${PORT_LANDING}"
-            # Production domain (e.g. nebari.example.com) — leave empty for dev-only installs.
-            # Set via: make frontend-client LANDING_HOST=nebari.example.com
-            - name: LANDING_HOST
-              value: "${LANDING_HOST}"
-            # Must match the NebariApp name — that's the convention the operator uses.
-            - name: CLIENT_ID
-              value: "nebari-landingpage"
-          command:
-            - /bin/bash
-            - -c
-            - |
-              set -e
-              KCADM="/opt/keycloak/bin/kcadm.sh"
-              REALM="nebari"
-
-              echo "Authenticating to Keycloak..."
-              $KCADM config credentials \
-                --server "$KEYCLOAK_URL" \
-                --realm master \
-                --user admin \
-                --password "$KEYCLOAK_ADMIN_PASSWORD"
-
-              # ── Resolve existing client ID (if any) ─────────────────────────
-              KC_CLIENT_UUID=$($KCADM get clients -r "$REALM" --fields id,clientId \
-                | tr -d ' \n' \
-                | grep -o "\"id\":\"[^\"]*\",\"clientId\":\"${CLIENT_ID}\"" \
-                | grep -o '"id":"[^"]*"' \
-                | cut -d'"' -f4)
-
-              # Build allowed redirect URI and web origin lists.
-              # Always register both port-forward (localhost) and MetalLB IP variants so
-              # either dev mode works without re-running this job.
-              # Also register the production domain if LANDING_HOST is set.
-              REDIRECT_URIS="[\"http://localhost:${LOCALHOST_PORT}/oauth2/callback\",\"http://${LANDING_IP}/oauth2/callback\""
-              WEB_ORIGINS="[\"http://localhost:${LOCALHOST_PORT}\",\"http://${LANDING_IP}\""
-              if [ -n "${LANDING_HOST}" ]; then
-                REDIRECT_URIS="${REDIRECT_URIS},\"https://${LANDING_HOST}/oauth2/callback\""
-                WEB_ORIGINS="${WEB_ORIGINS},\"https://${LANDING_HOST}\""
-              fi
-              REDIRECT_URIS="${REDIRECT_URIS}]"
-              WEB_ORIGINS="${WEB_ORIGINS}]"
-
-              if [ -n "$KC_CLIENT_UUID" ]; then
-                echo "Client '${CLIENT_ID}' already exists (uuid=${KC_CLIENT_UUID}), updating..."
-                $KCADM update clients/"$KC_CLIENT_UUID" -r "$REALM" \
-                  -s enabled=true \
-                  -s publicClient=false \
-                  -s clientAuthenticatorType=client-secret \
-                  -s secret="$CLIENT_SECRET" \
-                  -s standardFlowEnabled=true \
-                  -s directAccessGrantsEnabled=false \
-                  -s "redirectUris=$REDIRECT_URIS" \
-                  -s "webOrigins=$WEB_ORIGINS"
-              else
-                echo "Creating confidential client '${CLIENT_ID}'..."
-                $KCADM create clients -r "$REALM" \
-                  -s clientId="$CLIENT_ID" \
-                  -s enabled=true \
-                  -s publicClient=false \
-                  -s clientAuthenticatorType=client-secret \
-                  -s secret="$CLIENT_SECRET" \
-                  -s standardFlowEnabled=true \
-                  -s directAccessGrantsEnabled=false \
-                  -s "redirectUris=$REDIRECT_URIS" \
-                  -s "webOrigins=$WEB_ORIGINS"
-
-                KC_CLIENT_UUID=$($KCADM get clients -r "$REALM" --fields id,clientId \
-                  | tr -d ' \n' \
-                  | grep -o "\"id\":\"[^\"]*\",\"clientId\":\"${CLIENT_ID}\"" \
-                  | grep -o '"id":"[^"]*"' \
-                  | cut -d'"' -f4)
-              fi
-
-              echo "Keycloak client UUID: $KC_CLIENT_UUID"
-
-              # ── Groups mapper ─────────────────────────────────────────────────
-              $KCADM create clients/"$KC_CLIENT_UUID"/protocol-mappers/models -r "$REALM" \
-                -s name=groups \
-                -s protocol=openid-connect \
-                -s protocolMapper=oidc-group-membership-mapper \
-                -s 'config."full.path"=false' \
-                -s 'config."id.token.claim"=true' \
-                -s 'config."access.token.claim"=true' \
-                -s 'config."userinfo.token.claim"=true' \
-                -s 'config."claim.name"=groups' \
-                || echo "Groups mapper may already exist, skipping"
-
-              # ── Audience mapper ───────────────────────────────────────────────
-              # Adds the client ID to the 'aud' claim so resource servers can
-              # verify the token was intended for this client.
-              $KCADM create clients/"$KC_CLIENT_UUID"/protocol-mappers/models -r "$REALM" \
-                -s name=audience \
-                -s protocol=openid-connect \
-                -s protocolMapper=oidc-audience-mapper \
-                -s 'config."included.client.audience"=nebari-landingpage' \
-                -s 'config."id.token.claim"=false' \
-                -s 'config."access.token.claim"=true' \
-                || echo "Audience mapper may already exist, skipping"
-
-              echo "Keycloak nebari-landingpage client setup complete!"
-spec:
-  ttlSecondsAfterFinished: 300
-  template:
-    spec:
-      restartPolicy: OnFailure
-      containers:
-        - name: client-setup
-          image: quay.io/keycloak/keycloak:24.0
-          env:
-            - name: KEYCLOAK_ADMIN_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: keycloak-admin-credentials
-                  key: admin-password
-            - name: KEYCLOAK_URL
-              value: http://keycloak-keycloakx-http.keycloak.svc.cluster.local/auth
-            # Static dev secret — safe only for local minikube
-            - name: CLIENT_SECRET
-              value: "nebari-frontend-dev-secret"
-            # MetalLB pinned IP for the landing page service
+            # MetalLB pinned IP for the landing page Service
             - name: LANDING_IP
               value: "192.168.49.102"
             # Localhost port used by 'make port-forward' — must match PORT_LANDING (default 8080).
@@ -190,79 +67,116 @@ spec:
                 --user admin \
                 --password "$KEYCLOAK_ADMIN_PASSWORD"
 
-              # ── Resolve existing client ID (if any) ─────────────────────────
-              CLIENT_ID=$($KCADM get clients -r "$REALM" --fields id,clientId \
-                | tr -d ' \n' \
-                | grep -o '"id":"[^"]*","clientId":"nebari-landingpage"' \
-                | grep -o '"id":"[^"]*"' \
-                | cut -d'"' -f4)
-
-              # Build allowed redirect URI and web origin lists.
-              # Always register both port-forward (localhost) and MetalLB IP variants so
-              # either dev mode works without re-running this job.
-              # Also register the production domain if LANDING_HOST is set.
-              REDIRECT_URIS="[\"http://localhost:${LOCALHOST_PORT}/oauth2/callback\",\"http://${LANDING_IP}/oauth2/callback\""
-              WEB_ORIGINS="[\"http://localhost:${LOCALHOST_PORT}\",\"http://${LANDING_IP}\""
-              if [ -n "${LANDING_HOST}" ]; then
-                REDIRECT_URIS="${REDIRECT_URIS},\"https://${LANDING_HOST}/oauth2/callback\""
-                WEB_ORIGINS="${WEB_ORIGINS},\"https://${LANDING_HOST}\""
-              fi
-              REDIRECT_URIS="${REDIRECT_URIS}]"
-              WEB_ORIGINS="${WEB_ORIGINS}]"
-
-              if [ -n "$CLIENT_ID" ]; then
-                echo "Client 'nebari-landingpage' already exists (id=$CLIENT_ID), updating..."
-                $KCADM update clients/"$CLIENT_ID" -r "$REALM" \
-                  -s enabled=true \
-                  -s publicClient=false \
-                  -s clientAuthenticatorType=client-secret \
-                  -s secret="$CLIENT_SECRET" \
-                  -s standardFlowEnabled=true \
-                  -s directAccessGrantsEnabled=false \
-                  -s "redirectUris=$REDIRECT_URIS" \
-                  -s "webOrigins=$WEB_ORIGINS"
-              else
-                echo "Creating confidential client 'nebari-landingpage'..."
-                $KCADM create clients -r "$REALM" \
-                  -s clientId=nebari-landingpage \
-                  -s enabled=true \
-                  -s publicClient=false \
-                  -s clientAuthenticatorType=client-secret \
-                  -s secret="$CLIENT_SECRET" \
-                  -s standardFlowEnabled=true \
-                  -s directAccessGrantsEnabled=false \
-                  -s "redirectUris=$REDIRECT_URIS" \
-                  -s "webOrigins=$WEB_ORIGINS"
-
-                CLIENT_ID=$($KCADM get clients -r "$REALM" --fields id,clientId \
+              # ── Helper: upsert a client and echo its UUID ────────────────────
+              # Usage: upsert_client <clientId> <extra kcadm -s args...>
+              upsert_client() {
+                local client_id="$1"; shift
+                local existing_uuid
+                existing_uuid=$($KCADM get clients -r "$REALM" --fields id,clientId \
                   | tr -d ' \n' \
-                  | grep -o '"id":"[^"]*","clientId":"nebari-landingpage"' \
+                  | grep -o "\"id\":\"[^\"]*\",\"clientId\":\"${client_id}\"" \
                   | grep -o '"id":"[^"]*"' \
                   | cut -d'"' -f4)
+                if [ -n "$existing_uuid" ]; then
+                  echo "Client '${client_id}' already exists (uuid=${existing_uuid}), updating..." >&2
+                  $KCADM update "clients/${existing_uuid}" -r "$REALM" "$@"
+                  echo "$existing_uuid"
+                else
+                  echo "Creating client '${client_id}'..." >&2
+                  $KCADM create clients -r "$REALM" -s "clientId=${client_id}" "$@"
+                  $KCADM get clients -r "$REALM" --fields id,clientId \
+                    | tr -d ' \n' \
+                    | grep -o "\"id\":\"[^\"]*\",\"clientId\":\"${client_id}\"" \
+                    | grep -o '"id":"[^"]*"' \
+                    | cut -d'"' -f4
+                fi
+              }
+
+              # ── Helper: add a protocol mapper, skip if it already exists ─────
+              add_mapper_if_missing() {
+                local client_uuid="$1" mapper_name="$2"; shift 2
+                $KCADM create "clients/${client_uuid}/protocol-mappers/models" \
+                  -r "$REALM" -s "name=${mapper_name}" "$@" \
+                  || echo "Mapper '${mapper_name}' may already exist, skipping"
+              }
+
+              # ── 1. nebari-landingpage — confidential client for oauth2-proxy ──
+              LP_REDIRECT_URIS="[\"http://localhost:${LOCALHOST_PORT}/oauth2/callback\",\"http://${LANDING_IP}/oauth2/callback\""
+              LP_WEB_ORIGINS="[\"http://localhost:${LOCALHOST_PORT}\",\"http://${LANDING_IP}\""
+              if [ -n "${LANDING_HOST}" ]; then
+                LP_REDIRECT_URIS="${LP_REDIRECT_URIS},\"https://${LANDING_HOST}/oauth2/callback\""
+                LP_WEB_ORIGINS="${LP_WEB_ORIGINS},\"https://${LANDING_HOST}\""
               fi
+              LP_REDIRECT_URIS="${LP_REDIRECT_URIS}]"
+              LP_WEB_ORIGINS="${LP_WEB_ORIGINS}]"
 
-              echo "Frontend client ID: $CLIENT_ID"
+              LP_UUID=$(upsert_client nebari-landingpage \
+                -s enabled=true \
+                -s publicClient=false \
+                -s clientAuthenticatorType=client-secret \
+                -s secret="$CLIENT_SECRET" \
+                -s standardFlowEnabled=true \
+                -s directAccessGrantsEnabled=false \
+                -s "redirectUris=${LP_REDIRECT_URIS}" \
+                -s "webOrigins=${LP_WEB_ORIGINS}")
+              echo "nebari-landingpage UUID: $LP_UUID"
 
-              # ── Groups mapper ────────────────────────────────────────────────
-              $KCADM create clients/"$CLIENT_ID"/protocol-mappers/models -r "$REALM" \
-                -s name=groups \
+              add_mapper_if_missing "$LP_UUID" groups \
                 -s protocol=openid-connect \
                 -s protocolMapper=oidc-group-membership-mapper \
                 -s 'config."full.path"=false' \
                 -s 'config."id.token.claim"=true' \
                 -s 'config."access.token.claim"=true' \
                 -s 'config."userinfo.token.claim"=true' \
-                -s 'config."claim.name"=groups' \
-                || echo "Groups mapper may already exist, skipping"
+                -s 'config."claim.name"=groups'
 
-              # ── Audience mapper ───────────────────────────────────────────────
-              $KCADM create clients/"$CLIENT_ID"/protocol-mappers/models -r "$REALM" \
-                -s name=audience \
+              add_mapper_if_missing "$LP_UUID" audience \
                 -s protocol=openid-connect \
                 -s protocolMapper=oidc-audience-mapper \
                 -s 'config."included.client.audience"=nebari-landingpage' \
                 -s 'config."id.token.claim"=false' \
-                -s 'config."access.token.claim"=true' \
-                || echo "Audience mapper may already exist, skipping"
+                -s 'config."access.token.claim"=true'
 
-              echo "Keycloak nebari-landingpage client setup complete!"
+              echo "✔ nebari-landingpage configured"
+
+              # ── 2. nebari-frontend-spa — public PKCE client for keycloak-js ──
+              # publicClient=true means no client secret is required.
+              # PKCE S256 is enforced via the client attribute.
+              # Redirect URIs use /* wildcards so any SPA route works after login.
+              SPA_REDIRECT_URIS="[\"http://localhost:${LOCALHOST_PORT}/*\",\"http://${LANDING_IP}/*\""
+              SPA_WEB_ORIGINS="[\"http://localhost:${LOCALHOST_PORT}\",\"http://${LANDING_IP}\""
+              if [ -n "${LANDING_HOST}" ]; then
+                SPA_REDIRECT_URIS="${SPA_REDIRECT_URIS},\"https://${LANDING_HOST}/*\""
+                SPA_WEB_ORIGINS="${SPA_WEB_ORIGINS},\"https://${LANDING_HOST}\""
+              fi
+              SPA_REDIRECT_URIS="${SPA_REDIRECT_URIS}]"
+              SPA_WEB_ORIGINS="${SPA_WEB_ORIGINS}]"
+
+              SPA_UUID=$(upsert_client nebari-frontend-spa \
+                -s enabled=true \
+                -s publicClient=true \
+                -s standardFlowEnabled=true \
+                -s directAccessGrantsEnabled=false \
+                -s 'attributes."pkce.code.challenge.method"=S256' \
+                -s "redirectUris=${SPA_REDIRECT_URIS}" \
+                -s "webOrigins=${SPA_WEB_ORIGINS}")
+              echo "nebari-frontend-spa UUID: $SPA_UUID"
+
+              add_mapper_if_missing "$SPA_UUID" groups \
+                -s protocol=openid-connect \
+                -s protocolMapper=oidc-group-membership-mapper \
+                -s 'config."full.path"=false' \
+                -s 'config."id.token.claim"=true' \
+                -s 'config."access.token.claim"=true' \
+                -s 'config."userinfo.token.claim"=true' \
+                -s 'config."claim.name"=groups'
+
+              add_mapper_if_missing "$SPA_UUID" audience \
+                -s protocol=openid-connect \
+                -s protocolMapper=oidc-audience-mapper \
+                -s 'config."included.client.audience"=nebari-landingpage' \
+                -s 'config."id.token.claim"=false' \
+                -s 'config."access.token.claim"=true'
+
+              echo "✔ nebari-frontend-spa configured"
+              echo "Keycloak client setup complete!"

--- a/dev/keycloak/nebari-realm.json
+++ b/dev/keycloak/nebari-realm.json
@@ -44,8 +44,37 @@
   "clients": [
     {
       "clientId": "nebari-landingpage",
-      "name": "Nebari Landing Page",
-      "description": "Frontend SPA for the Nebari landing page",
+      "name": "Nebari Landing Page (oauth2-proxy)",
+      "description": "Confidential OIDC client used by the oauth2-proxy sidecar in production",
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "publicClient": false,
+      "secret": "nebari-frontend-dev-secret",
+      "protocol": "openid-connect",
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "http://localhost:*",
+        "https://nebari.example.com/*"
+      ],
+      "webOrigins": [
+        "http://localhost:*",
+        "https://nebari.example.com"
+      ],
+      "fullScopeAllowed": false,
+      "defaultClientScopes": [
+        "openid",
+        "profile",
+        "email",
+        "roles"
+      ]
+    },
+    {
+      "clientId": "nebari-frontend-spa",
+      "name": "Nebari Frontend SPA",
+      "description": "Public OIDC client for keycloak-js PKCE flow in the browser",
       "enabled": true,
       "clientAuthenticatorType": "client-secret",
       "publicClient": true,

--- a/dev/manifests/test-nebariapps.yaml
+++ b/dev/manifests/test-nebariapps.yaml
@@ -14,7 +14,7 @@ spec:
     enabled: true
     displayName: "Documentation"
     description: "Nebari platform documentation and guides"
-    icon: "kubernetes"
+    icon: "https://fontawesome.com/icons/kubernetes?f=brands&s=solid"
     category: "Platform"
     priority: 10
     visibility: public
@@ -24,7 +24,7 @@ spec:
       intervalSeconds: 30
       timeoutSeconds: 5
 ---
-# Authenticated service — requires valid JWT
+# Private service — requires valid JWT (any authenticated user, no group restriction)
 apiVersion: reconcilers.nebari.dev/v1
 kind: NebariApp
 metadata:
@@ -39,17 +39,18 @@ spec:
     enabled: true
     displayName: "JupyterHub"
     description: "Interactive Python notebooks for data science"
-    icon: "jupyter"
+    # https://github.com/jupyter/jupyter.github.io/blob/main/assets/share.png
+    icon: "https://jupyter.org/assets/homepage/main-logo.svg"
     category: "Data Science"
     priority: 1
-    visibility: authenticated
+    visibility: private
     healthCheck:
       enabled: true
       path: "/healthz"
       intervalSeconds: 30
       timeoutSeconds: 5
 ---
-# Authenticated service — second card in same category
+# Private service — requires valid JWT (any authenticated user, no group restriction)
 apiVersion: reconcilers.nebari.dev/v1
 kind: NebariApp
 metadata:
@@ -64,10 +65,10 @@ spec:
     enabled: true
     displayName: "Grafana"
     description: "Platform metrics and dashboards"
-    icon: "grafana"
+    icon: "https://upload.wikimedia.org/wikipedia/commons/a/a1/Grafana_logo.svg"
     category: "Monitoring"
     priority: 20
-    visibility: authenticated
+    visibility: private
 ---
 # Private service — requires JWT + admin group membership
 apiVersion: reconcilers.nebari.dev/v1
@@ -84,8 +85,9 @@ spec:
     enabled: true
     displayName: "Admin Panel"
     description: "Cluster administration — restricted access"
-    icon: "keycloak"
+    # https://github.com/keycloak/keycloak-misc/blob/main/logo/logo-icon.png
     category: "Platform"
+    icon: "https://raw.githubusercontent.com/keycloak/keycloak-misc/main/logo/logo-icon.png"
     priority: 999
     visibility: private
     requiredGroups:

--- a/dev/nginx.conf
+++ b/dev/nginx.conf
@@ -1,4 +1,12 @@
 # ── Main nginx config (non-root safe) ────────────────────────────────────────
+# This file is used as a TEMPLATE — ${WEBAPI_URL} is substituted at container
+# startup by envsubst (see dev/Dockerfile CMD). Set the WEBAPI_URL env var to
+# point at the webapi ClusterIP/service when running in-cluster; defaults to
+# the standard Helm-installed ClusterIP DNS name.
+#
+# NOTE: In the full Helm deployment the ConfigMap (charts/.../frontend/configmap.yaml)
+# overrides this file at runtime, so changes here only affect the docker-only
+# (non-Helm) dev workflow. The production nginx.conf is authoritative.
 worker_processes auto;
 pid /tmp/nginx.pid;
 
@@ -26,6 +34,12 @@ http {
     access_log /dev/stdout main;
     error_log  /dev/stderr warn;
 
+    # WebSocket upgrade map (required for /api/v1/ws)
+    map $http_upgrade $connection_upgrade {
+        default   upgrade;
+        ''        close;
+    }
+
     # Extract Bearer token injected by oauth2-proxy upstream header.
     # The SPA calls GET /auth-token to retrieve the token for webapi calls.
     map $http_authorization $bearer_token {
@@ -46,6 +60,27 @@ server {
                text/xml application/xml application/xml+rss text/javascript
                image/svg+xml;
     gzip_min_length 1024;
+
+    # ── /api/ → webapi back-end ───────────────────────────────────────────────
+    # Proxy all API calls (including WebSocket upgrades for /api/v1/ws) to the
+    # webapi service. oauth2-proxy has already injected Authorization: Bearer
+    # <token> at this point, so $http_authorization carries the JWT that the
+    # webapi needs to validate and serve the correct visibility bucket.
+    # WEBAPI_URL is substituted by envsubst at container startup; it defaults to
+    # the Helm-installed ClusterIP DNS name and can be overridden via env var.
+    location /api/ {
+        proxy_pass         ${WEBAPI_URL}/api/;
+        proxy_set_header   Authorization   $http_authorization;
+        proxy_set_header   X-Real-IP       $remote_addr;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   Host            $host;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade         $http_upgrade;
+        proxy_set_header   Connection      $connection_upgrade;
+        # Long timeouts for streaming / WebSocket connections.
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
 
     # Cache static assets
     location ~* \.(js|css|png|svg|ico|woff2?|ttf|eot)$ {

--- a/dev/webapi_test.py
+++ b/dev/webapi_test.py
@@ -3,21 +3,34 @@
 Local WebAPI integration test script for the Nebari landing page.
 
 Runs a series of checks against the port-forwarded webapi and Keycloak:
-  - Unauthenticated /api/v1/services  → only public bucket populated
-  - Authenticated /api/v1/services    → public + authenticated buckets
+  - Unauthenticated /api/v1/services  → only public services visible
+  - Authenticated /api/v1/services    → public + private services visible
   - /api/v1/categories
   - /api/v1/health
   - Single service lookup (authenticated)
+  - GET /api/v1/debug (when webapi is started with debugMode=true / --debug)
+
+Visibility model (2-tier):
+  public   → visible to all users, no authentication required
+  private  → requires valid JWT; if requiredGroups is set the caller must also
+             be a member of at least one listed group (the operator always
+             creates a Keycloak group per NebariApp)
 
 Prerequisites:
     pip install requests
 
 Port-forwards (run in separate terminals before this script):
     kubectl -n keycloak      port-forward svc/keycloak-keycloakx-http 8180:80
-    kubectl -n nebari-system port-forward svc/webapi                  8090:8080
+    kubectl -n nebari-system port-forward svc/nebari-landing-webapi   8090:8080
 
 Also apply test NebariApps:
     make -f dev/Makefile test-apps
+
+Enable debug mode in the webapi (restarts the pod):
+    # Option A — set debugMode=true in dev/chart-values.yaml then reinstall:
+    make -f dev/Makefile install
+    # Option B — one-shot env override (no Helm re-install):
+    kubectl -n nebari-system set env deployment/nebari-landing-webapi DEBUG_MODE=true
 
 Usage:
     python dev/webapi_test.py
@@ -38,10 +51,10 @@ except ImportError:
     sys.exit("Missing dependency: pip install requests")
 
 # ── Local defaults (port-forwarded) ───────────────────────────────────────────
-KEYCLOAK_URL  = "http://localhost:8180/auth"
-WEBAPI_URL    = "http://localhost:8090"
+KEYCLOAK_URL = "http://localhost:8180/auth"
+WEBAPI_URL = "http://localhost:8090"
 DEFAULT_REALM = "nebari"
-DEFAULT_PATH  = "/api/v1/services"
+DEFAULT_PATH = "/api/v1/services"
 
 PASS_MARK = "✅"
 FAIL_MARK = "❌"
@@ -49,6 +62,7 @@ SKIP_MARK = "⚠️ "
 
 
 # ── Auth helpers ───────────────────────────────────────────────────────────────
+
 
 def get_token_password(
     keycloak_url: str,
@@ -86,6 +100,7 @@ def dump(obj: dict, indent: int = 2) -> str:
 
 # ── Test runners ───────────────────────────────────────────────────────────────
 
+
 def check(label: str, condition: bool, detail: str = "") -> bool:
     mark = PASS_MARK if condition else FAIL_MARK
     suffix = f"  ({detail})" if detail else ""
@@ -97,6 +112,56 @@ def section(title: str) -> None:
     print(f"\n{'─' * 60}")
     print(f"  {title}")
     print(f"{'─' * 60}")
+
+
+def run_debug(webapi_url: str, token: Optional[str] = None) -> dict:
+    """Call GET /api/v1/debug and pretty-print the response.
+
+    The endpoint is only available when the webapi is started with
+    --debug / DEBUG_MODE=true.  It shows request headers (Bearer tokens
+    redacted), resolved JWT claims, and per-visibility service counts.
+    Use this to diagnose "only public services show up" issues.
+    """
+    section("GET /api/v1/debug  (requires DEBUG_MODE=true on webapi)")
+    try:
+        r = call_api(webapi_url, "/api/v1/debug", token)
+        if r.status_code == 404:
+            print(
+                f"  {SKIP_MARK}  /api/v1/debug returned 404 — start the webapi with "
+                "DEBUG_MODE=true (or debugMode: true in chart-values.yaml)"
+            )
+            return {}
+        check("HTTP 200", r.status_code == 200, f"got {r.status_code}")
+        body = r.json()
+        auth = body.get("auth", {})
+        services = body.get("services", {})
+
+        check("auth.enabled reported", "enabled" in auth)
+        check("auth.authenticated field", "authenticated" in auth)
+
+        print(f"\n  ── auth ──")
+        print(f"  enabled:              {auth.get('enabled')}")
+        print(f"  validator_configured: {auth.get('validator_configured')}")
+        print(f"  authenticated:        {auth.get('authenticated')}")
+        if auth.get("authenticated"):
+            print(f"  username:             {auth.get('username')}")
+            print(f"  email:                {auth.get('email')}")
+            print(f"  groups:               {auth.get('groups')}")
+        elif auth.get("validation_error"):
+            print(f"  validation_error:     {auth.get('validation_error')}")
+
+        print(f"\n  ── services ──")
+        print(f"  total_in_cache:   {services.get('total_in_cache', 0)}")
+        print(f"  visible_public:   {services.get('visible_public', 0)}")
+        print(f"  visible_private:  {services.get('visible_private', 0)}")
+        print(f"  hidden_to_caller: {services.get('hidden_to_caller', 0)}")
+
+        auth_hdr = body.get("request", {}).get("headers", {}).get("Authorization", "<absent>")
+        print(f"\n  Authorization header: {auth_hdr}")
+        return body
+    except Exception as e:
+        check("Request succeeded", False, str(e))
+        return {}
 
 
 def run_health_check(webapi_url: str) -> bool:
@@ -120,24 +185,22 @@ def run_unauthenticated_services(webapi_url: str) -> dict:
         check("HTTP 200", r.status_code == 200, f"got {r.status_code}")
         body = r.json()
         services = body.get("services", {})
-        public        = services.get("public", [])
+        public = services.get("public", [])
         authenticated = services.get("authenticated", [])
-        private       = services.get("private", [])
-        user          = body.get("user")
+        private = services.get("private", [])
+        user = body.get("user")
 
-        check("public bucket present",        isinstance(public, list))
-        check("authenticated bucket empty",   len(authenticated) == 0,
-              f"expected 0, got {len(authenticated)}")
-        check("private bucket empty",         len(private) == 0,
-              f"expected 0, got {len(private)}")
-        check("user field absent",            user is None,
-              "user should be omitted when unauthenticated")
-        check("disabled-app not in public",
-              not any(s.get("name") == "disabled-app" for s in public))
+        check("public bucket present", isinstance(public, list))
+        check("authenticated bucket empty", len(authenticated) == 0, f"expected 0, got {len(authenticated)}")
+        check("private bucket empty", len(private) == 0, f"expected 0, got {len(private)}")
+        check("user field absent", user is None, "user should be omitted when unauthenticated")
+        check("disabled-app not in public", not any(s.get("name") == "disabled-app" for s in public))
 
         print(f"\n  Public services ({len(public)}):")
         for s in public:
-            print(f"    • {s.get('displayName')} [{s.get('category')}] (priority={s.get('priority')}) url={s.get('url')}")
+            print(
+                f"    • {s.get('displayName')} [{s.get('category')}] (priority={s.get('priority')}) url={s.get('url')}"
+            )
         return body
     except Exception as e:
         check("Request succeeded", False, str(e))
@@ -150,31 +213,19 @@ def run_authenticated_services(webapi_url: str, token: str, realm_admin_password
         r = call_api(webapi_url, "/api/v1/services", token)
         check("HTTP 200", r.status_code == 200, f"got {r.status_code}")
         body = r.json()
-        services = body.get("services", {})
-        public        = services.get("public", [])
-        authenticated = services.get("authenticated", [])
-        private       = services.get("private", [])
-        user          = body.get("user", {})
-        categories    = body.get("categories", [])
+        # Response shape: {"services": [...]}
+        services = body.get("services", [])
+        check("services key is a list", isinstance(services, list), f"got {type(services).__name__}")
+        check("at least one service visible when authenticated", len(services) > 0, f"got {len(services)}")
 
-        check("public bucket present",            len(public) > 0)
-        check("authenticated bucket present",     len(authenticated) > 0,
-              f"got {len(authenticated)}")
-        check("private bucket present (admin)",   len(private) > 0,
-              f"got {len(private)} (admin group membership required)")
-        check("user.authenticated=true",          user.get("authenticated") is True)
-        check("user.username=admin",              user.get("username") == "admin",
-              f"got '{user.get('username')}'")
-        check("categories is list",               isinstance(categories, list))
-        check("categories non-empty",             len(categories) > 0, str(categories))
-        check("categories sorted",
-              categories == sorted(categories), str(categories))
+        # The test apps include 1 public + 2 private (no groups) + 1 private (admin group).
+        # As admin we should see all non-disabled services.
+        check("more services than without token", len(services) > 0, "admin should see private services too")
+        check("disabled-app not in response", not any(s.get("name") == "disabled-app" for s in services))
 
-        print(f"\n  Public ({len(public)}):        ", [s['displayName'] for s in public])
-        print(f"  Authenticated ({len(authenticated)}): ", [s['displayName'] for s in authenticated])
-        print(f"  Private ({len(private)}):       ", [s['displayName'] for s in private])
-        print(f"  Categories: {categories}")
-        print(f"  User: {dump(user)}")
+        print(f"\n  Services visible as admin ({len(services)}):")
+        for s in services:
+            print(f"    \u2022 {s.get('name')} [{s.get('category')}] url={s.get('url')}")
         return body
     except Exception as e:
         check("Request succeeded", False, str(e))
@@ -188,9 +239,9 @@ def run_single_service(webapi_url: str, token: str, namespace: str, name: str) -
         check("HTTP 200", r.status_code == 200, f"got {r.status_code}")
         if r.status_code == 200:
             s = r.json()
-            check("name matches",    s.get("name") == name)
-            check("has url field",   bool(s.get("url")))
-            check("has category",    bool(s.get("category")))
+            check("name matches", s.get("name") == name)
+            check("has url field", bool(s.get("url")))
+            check("has category", bool(s.get("category")))
             check("has displayName", bool(s.get("displayName")))
             print(f"\n  {dump(s)}")
     except Exception as e:
@@ -205,8 +256,8 @@ def run_categories(webapi_url: str) -> None:
         body = r.json()
         cats = body.get("categories", [])
         check("categories key present", "categories" in body)
-        check("categories is list",     isinstance(cats, list))
-        check("categories sorted",      cats == sorted(cats), str(cats))
+        check("categories is list", isinstance(cats, list))
+        check("categories sorted", cats == sorted(cats), str(cats))
         print(f"\n  {cats}")
     except Exception as e:
         check("Request succeeded", False, str(e))
@@ -228,8 +279,7 @@ def run_pins(webapi_url: str, token: str, uid: Optional[str]) -> None:
         check("GET /api/v1/pins → 200", r2.status_code == 200)
         pins_body = r2.json()
         check("uid in stored uids", uid in pins_body.get("uids", []))
-        check("service in pins list",
-              any(p.get("uid") == uid for p in pins_body.get("pins", [])))
+        check("service in pins list", any(p.get("uid") == uid for p in pins_body.get("pins", [])))
 
         # DELETE pin
         r3 = requests.delete(url, headers={"Authorization": f"Bearer {token}"}, timeout=10)
@@ -240,29 +290,35 @@ def run_pins(webapi_url: str, token: str, uid: Optional[str]) -> None:
 
 # ── CLI ────────────────────────────────────────────────────────────────────────
 
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Nebari WebAPI integration tests (local port-forward)")
-    parser.add_argument("--keycloak-url", default=KEYCLOAK_URL,
-                        help=f"Keycloak base URL with /auth (default: {KEYCLOAK_URL})")
-    parser.add_argument("--webapi-url", default=WEBAPI_URL,
-                        help=f"WebAPI base URL (default: {WEBAPI_URL})")
-    parser.add_argument("--realm", default=DEFAULT_REALM,
-                        help=f"Keycloak realm (default: {DEFAULT_REALM})")
-    parser.add_argument("--path", default=None,
-                        help="Run a single ad-hoc GET against this path (skips test suite)")
+    parser.add_argument(
+        "--keycloak-url", default=KEYCLOAK_URL, help=f"Keycloak base URL with /auth (default: {KEYCLOAK_URL})"
+    )
+    parser.add_argument("--webapi-url", default=WEBAPI_URL, help=f"WebAPI base URL (default: {WEBAPI_URL})")
+    parser.add_argument("--realm", default=DEFAULT_REALM, help=f"Keycloak realm (default: {DEFAULT_REALM})")
+    parser.add_argument("--path", default=None, help="Run a single ad-hoc GET against this path (skips test suite)")
     parser.add_argument("-u", "--username", default="admin")
     parser.add_argument("-p", "--password", help="Keycloak password (prompted if omitted)")
     parser.add_argument("--client-id", default="webapi")
     parser.add_argument("--client-secret", default=None)
+    parser.add_argument(
+        "--debug-check", action="store_true", help="Run GET /api/v1/debug after the test suite to show auth state"
+    )
     args = parser.parse_args()
 
     # ── Ad-hoc single path mode ────────────────────────────────────────────────
     if args.path:
         password = args.password or getpass.getpass("Password: ")
-        token = get_token_password(args.keycloak_url, args.realm,
-                                   args.username, password,
-                                   client_id=args.client_id,
-                                   client_secret=args.client_secret)
+        token = get_token_password(
+            args.keycloak_url,
+            args.realm,
+            args.username,
+            password,
+            client_id=args.client_id,
+            client_secret=args.client_secret,
+        )
         r = call_api(args.webapi_url, args.path, token)
         print(f"HTTP {r.status_code}")
         try:
@@ -290,8 +346,12 @@ def main() -> None:
     password = args.password or getpass.getpass("Password (default realm admin): ")
     try:
         token = get_token_password(
-            args.keycloak_url, args.realm, args.username, password,
-            client_id=args.client_id, client_secret=args.client_secret,
+            args.keycloak_url,
+            args.realm,
+            args.username,
+            password,
+            client_id=args.client_id,
+            client_secret=args.client_secret,
         )
         check("Token obtained", True, f"user={args.username}")
     except requests.HTTPError as exc:
@@ -304,21 +364,18 @@ def main() -> None:
     # 5. Categories
     run_categories(args.webapi_url)
 
-    # 6. Single service lookup
-    all_services = (
-        auth_body.get("services", {}).get("public", []) +
-        auth_body.get("services", {}).get("authenticated", [])
-    )
+    # 6. Single service lookup (use first service from the authenticated response)
+    all_services = auth_body.get("services", [])
     if all_services:
         first = all_services[0]
-        run_single_service(args.webapi_url, token,
-                           first.get("namespace", "nebari-system"),
-                           first.get("name", ""))
+        run_single_service(args.webapi_url, token, first.get("namespace", "nebari-system"), first.get("name", ""))
 
     # 7. Pins
-    uid = all_services[0].get("uid") if all_services else None
+    uid = all_services[0].get("id") if all_services else None
     run_pins(args.webapi_url, token, uid)
-
+    # 8. Debug endpoint (optional — requires DEBUG_MODE=true on webapi)
+    if args.debug_check:
+        run_debug(args.webapi_url, token)
     print("\n" + "═" * 62)
     print("  Tests complete.")
     print("═" * 62 + "\n")

--- a/frontend/public/config.json
+++ b/frontend/public/config.json
@@ -2,6 +2,6 @@
   "keycloak": {
     "url":      "http://localhost:8180/auth",
     "realm":    "nebari",
-    "clientId": "nebari-landingpage"
+    "clientId": "nebari-frontend-spa"
   }
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,19 +1,16 @@
 /**
  * Shared API client for webapi calls.
  *
- * Architecture (production):
- *   Browser → Gateway HTTPRoute → /* → frontend Service (oauth2-proxy)
- *     → oauth2-proxy validates session cookie, injects Authorization: Bearer <token>
- *       → nginx (127.0.0.1:8080)
- *         → /api/* proxy_pass → webapi ClusterIP (cluster DNS, never public)
- *
- * The browser never communicates with the webapi directly. All auth token
- * forwarding happens server-side: oauth2-proxy → nginx → webapi.
- * The SPA only needs to include the session cookie (credentials: "include").
+ * Auth: the SPA authenticates directly with Keycloak (PKCE/S256) via keycloak-js
+ * and attaches the access token as `Authorization: Bearer <token>` on every
+ * request. This works in both dev (no oauth2-proxy) and production (oauth2-proxy
+ * may also inject the header server-side — harmless duplication, same token).
  *
  * In local dev (Vite dev server), the vite.config.ts proxy forwards /api/*
  * to the webapi running on localhost. Set VITE_WEBAPI_URL to override.
  */
+
+import { getToken } from "../auth/keycloak";
 
 const API_BASE = "/api/v1";
 
@@ -24,9 +21,10 @@ type RequestOptions = Omit<RequestInit, "headers"> & {
 /**
  * Authenticated fetch wrapper.
  *
- * Prepends /api/v1 to the given path and includes the session cookie so that
- * oauth2-proxy can validate the request and forward the Bearer token to the
- * webapi via nginx.
+ * Prepends /api/v1 to the given path, attaches the current Keycloak access
+ * token as `Authorization: Bearer <token>` when one is available, and also
+ * includes the session cookie so that oauth2-proxy (when present in production)
+ * can independently validate the session.
  */
 export async function apiFetch(
     path: string,
@@ -34,11 +32,17 @@ export async function apiFetch(
 ): Promise<Response> {
     const url = `${API_BASE}${path.startsWith("/") ? path : `/${path}`}`;
 
+    const token = await getToken();
+    const authHeader: Record<string, string> = token
+        ? { Authorization: `Bearer ${token}` }
+        : {};
+
     return fetch(url, {
         credentials: "include",
         ...options,
         headers: {
             "Content-Type": "application/json",
+            ...authHeader,
             ...options.headers,
         },
     });

--- a/frontend/src/app/main.tsx
+++ b/frontend/src/app/main.tsx
@@ -7,8 +7,9 @@ import "@trussworks/react-uswds/lib/index.css";
 const root = createRoot(document.getElementById('root')!);
 
 // Simple path-based routing without a router library.
-// oauth2-proxy enforces auth at the network level — /public is whitelisted
-// via --skip-auth-route so PublicPage renders without a session cookie.
+// /public is the unauthenticated landing page — no Keycloak init needed.
+// Every other route requires authentication: initKeycloak() performs the PKCE
+// login flow and redirects to Keycloak if the user has no valid session.
 if (window.location.pathname.startsWith('/public')) {
   const { default: PublicPage } = await import('../pages/PublicPage.tsx');
   root.render(
@@ -17,6 +18,9 @@ if (window.location.pathname.startsWith('/public')) {
     </StrictMode>,
   );
 } else {
+  const { initKeycloak } = await import('../auth/keycloak.ts');
+  await initKeycloak();
+
   const { default: App } = await import('./index.tsx');
   root.render(
     <StrictMode>

--- a/frontend/src/auth/keycloak.ts
+++ b/frontend/src/auth/keycloak.ts
@@ -3,32 +3,97 @@
 // and mounted by the frontend ConfigMap into the nginx container.
 // In local dev (Vite dev server / dev-watch) the file comes from
 // frontend/public/config.json, which holds local defaults.
+//
+// Auth flow: the SPA uses keycloak-js with PKCE (S256) to authenticate
+// directly with Keycloak and obtain an access token. The token is attached
+// as `Authorization: Bearer <token>` on every API request by apiFetch().
+// In production, nginx/oauth2-proxy may also inject the header server-side;
+// both mechanisms are harmless when present together — whichever reaches
+// the webapi first is validated the same way.
+
+import Keycloak from "keycloak-js";
 
 type KeycloakConfig = { url: string; realm: string; clientId: string };
 
 let _config: KeycloakConfig | null = null;
+let _keycloak: Keycloak | null = null;
 
 /**
  * Load Keycloak connection settings from the runtime config endpoint.
  * Cached after the first successful fetch — safe to call multiple times.
  */
-export async function loadKeycloakConfig(): Promise<KeycloakConfig> {
-    if (_config) return _config;
-    const res = await fetch("/config.json");
-    if (!res.ok) throw new Error(`Failed to load /config.json: ${res.status}`);
-    const data = await res.json();
-    _config = data.keycloak as KeycloakConfig;
-    return _config;
+async function loadKeycloakConfig(): Promise<KeycloakConfig> {
+  if (_config) return _config;
+  const res = await fetch("/config.json");
+  if (!res.ok) throw new Error(`Failed to load /config.json: ${res.status}`);
+  const data = await res.json();
+  _config = data.keycloak as KeycloakConfig;
+  return _config;
 }
 
+/**
+ * Initialise Keycloak.js and perform the OIDC login flow (PKCE/S256).
+ *
+ * Must be called once before the authenticated app is rendered.
+ * Redirects to the Keycloak login page if the user has no valid session;
+ * the redirect back resumes this call transparently.
+ *
+ * Returns the initialised Keycloak instance.
+ */
+export async function initKeycloak(): Promise<Keycloak> {
+  if (_keycloak) return _keycloak;
+
+  const cfg = await loadKeycloakConfig();
+  const kc = new Keycloak({ url: cfg.url, realm: cfg.realm, clientId: cfg.clientId });
+
+  await kc.init({
+    onLoad: "login-required",
+    pkceMethod: "S256",
+    checkLoginIframe: false,
+  });
+
+  _keycloak = kc;
+  return kc;
+}
+
+/** Returns the raw Keycloak instance (null until initKeycloak resolves). */
+export function getKeycloakInstance(): Keycloak | null {
+  return _keycloak;
+}
+
+/**
+ * Returns the current access token, refreshing it first if it expires within
+ * 30 seconds. Returns undefined if Keycloak has not been initialised or the
+ * session is no longer valid (in which case keycloak-js triggers a re-login).
+ */
+export async function getToken(): Promise<string | undefined> {
+  if (!_keycloak?.authenticated) return undefined;
+  try {
+    await _keycloak.updateToken(30);
+  } catch {
+    // Refresh failed (e.g. session expired) — force a new login.
+    _keycloak.login();
+    return undefined;
+  }
+  return _keycloak.token;
+}
+
+/** Trigger Keycloak login (redirects the browser). */
 export function signIn() {
-  // rd = where to send the browser after auth finishes
-  window.location.href = "/oauth2/start?rd=/";
+  if (_keycloak) {
+    _keycloak.login({ redirectUri: window.location.origin + "/" });
+  } else {
+    // Keycloak not yet initialised (e.g. called from the public page).
+    // Redirect to the authenticated zone which will trigger the login flow.
+    window.location.href = "/";
+  }
 }
 
+/** Trigger Keycloak logout (redirects the browser). */
 export function signOut() {
-  // Redirect to /public after clearing the session.
-  // /public is whitelisted in oauth2-proxy (--skip-auth-route), so the user
-  // lands on the public page instead of being bounced back to Keycloak login.
-  window.location.href = "/oauth2/sign_out?rd=/public";
+  if (_keycloak) {
+    _keycloak.logout({ redirectUri: window.location.origin + "/public" });
+  } else {
+    window.location.href = "/public";
+  }
 }

--- a/frontend/src/auth/user.ts
+++ b/frontend/src/auth/user.ts
@@ -1,4 +1,5 @@
-import { useState, useEffect } from "react";
+import { useMemo } from "react";
+import { getKeycloakInstance } from "./keycloak";
 
 export type User = {
     name: string;
@@ -6,37 +7,30 @@ export type User = {
 };
 
 /**
- * Fetches the authenticated user from oauth2-proxy's /oauth2/userinfo endpoint.
+ * Returns the authenticated user from the Keycloak ID token.
  *
- * oauth2-proxy injects the authenticated user's claims as JSON at this endpoint
- * when a valid session cookie is present. A 401/403 response means the user is
- * not yet logged in.
- *
- * Typical Keycloak response shape:
- *   { user: "john.doe@example.com", email: "...", preferredUsername: "john.doe",
- *     name: "John Doe", groups: [...] }
+ * When Keycloak.js has been initialised and the user is authenticated, the
+ * user object is derived synchronously from the parsed ID token — no network
+ * call required. Returns null when the Keycloak instance is not yet ready
+ * (e.g. on the public page where initKeycloak() is never called).
  */
 export function useUser(): { user: User | null; loading: boolean } {
-    const [user, setUser] = useState<User | null>(null);
-    const [loading, setLoading] = useState(true);
+    const user = useMemo<User | null>(() => {
+        const kc = getKeycloakInstance();
+        if (!kc?.authenticated || !kc.idTokenParsed) return null;
 
-    useEffect(() => {
-        fetch("/oauth2/userinfo", { credentials: "include" })
-            .then((r) => (r.ok ? r.json() : Promise.reject()))
-            .then((data: Record<string, string>) => {
-                const name =
-                    data["name"] ||
-                    data["preferredUsername"] ||
-                    data["user"] ||
-                    "User";
-                const email = data["email"] || "";
-                setUser({ name, email });
-            })
-            .catch(() => setUser(null))
-            .finally(() => setLoading(false));
+        const parsed = kc.idTokenParsed as Record<string, string>;
+        const name =
+            parsed["name"] ||
+            parsed["preferred_username"] ||
+            parsed["sub"] ||
+            "User";
+        const email = parsed["email"] || "";
+        return { name, email };
     }, []);
 
-    return { user, loading };
+    // Keycloak.js resolves synchronously after initKeycloak() — never loading.
+    return { user, loading: false };
 }
 
 /** Derive up-to-two initials from a display name, e.g. "John Doe" → "JD". */

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -43,6 +44,15 @@ type Handler struct {
 	// it talks to the frontend or /api/*, so CORS is not triggered. This flag
 	// is primarily useful for local Vite dev (localhost:5173 → localhost:8080).
 	allowedOrigins []string
+	// debugMode enables the GET /api/v1/debug endpoint which exposes request
+	// headers, resolved auth claims, and per-visibility service counts to aid
+	// in diagnosing auth and proxy-forwarding issues (similar to Keycloak's
+	// KC_HOSTNAME_DEBUG mode). Never enable in production.
+	debugMode bool
+	// claimsExtractor, when non-nil, replaces the JWT validation step.
+	// Use WithClaimsExtractor in tests to inject synthetic claims without
+	// needing a real Keycloak instance or signed token.
+	claimsExtractor func(*http.Request) (*auth.Claims, bool)
 }
 
 // HandlerOption configures optional Handler fields.
@@ -87,6 +97,28 @@ func WithAllowedOrigins(origins []string) HandlerOption {
 	}
 }
 
+// WithDebugMode enables the GET /api/v1/debug endpoint which dumps request
+// headers, resolved JWT claims, and per-visibility service counts to aid in
+// diagnosing auth and proxy-forwarding issues. Never enable in production.
+func WithDebugMode() HandlerOption {
+	return func(h *Handler) { h.debugMode = true }
+}
+
+// WithClaimsExtractor replaces the JWT validation step with a custom function.
+// Intended for unit tests that need to simulate authenticated requests without
+// a real Keycloak instance or signed JWT. The function receives the request and
+// returns the synthetic claims plus an authenticated flag.
+//
+// Example (test-only):
+//
+//	h := NewHandler(sc, nil, true, nil, nil,
+//	    WithClaimsExtractor(func(_ *http.Request) (*auth.Claims, bool) {
+//	        return &auth.Claims{PreferredUsername: "alice", Groups: []string{"admin"}}, true
+//	    }))
+func WithClaimsExtractor(fn func(*http.Request) (*auth.Claims, bool)) HandlerOption {
+	return func(h *Handler) { h.claimsExtractor = fn }
+}
+
 // NewHandler creates a new API handler.
 // pinStore may be nil; when nil the /api/v1/pins endpoints return 501.
 func NewHandler(serviceCache *cache.ServiceCache, jwtValidator *auth.JWTValidator, enableAuth bool, hub *wshub.Hub, pinStore *pins.PinStore, opts ...HandlerOption) *Handler {
@@ -124,6 +156,13 @@ func (h *Handler) Routes() http.Handler {
 
 	// Caller identity — returns JWT claims for the requesting user
 	mux.HandleFunc("/api/v1/caller-identity", h.handleCallerIdentity)
+
+	// Debug endpoint — only registered when debug mode is enabled.
+	// Shows request headers, resolved JWT claims, and service visibility counts.
+	// Use --debug / DEBUG_MODE=true to activate. Never enable in production.
+	if h.debugMode {
+		mux.HandleFunc("/api/v1/debug", h.handleDebug)
+	}
 
 	// User pins — requires authentication; 501 when no PinStore is configured
 	mux.HandleFunc("/api/v1/pins", h.handleGetPins)
@@ -713,18 +752,32 @@ func (h *Handler) handleHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) extractAndValidateJWT(r *http.Request) (*auth.Claims, bool) {
+	// Test/debug hook: use the injected extractor when present.
+	if h.claimsExtractor != nil {
+		return h.claimsExtractor(r)
+	}
+
 	if !h.enableAuth || h.jwtValidator == nil {
+		if h.debugMode {
+			log.Info("[debug] JWT extraction skipped",
+				"enableAuth", h.enableAuth,
+				"validatorConfigured", h.jwtValidator != nil)
+		}
 		return nil, false
 	}
 
 	authHeader := r.Header.Get("Authorization")
 	if authHeader == "" {
+		if h.debugMode {
+			log.Info("[debug] No Authorization header on request", "path", r.URL.Path)
+		}
 		return nil, false
 	}
 
 	parts := strings.Split(authHeader, " ")
 	if len(parts) != 2 || parts[0] != "Bearer" {
-		log.Info("Invalid Authorization header format")
+		log.Info("Invalid Authorization header format",
+			"scheme", parts[0], "path", r.URL.Path)
 		return nil, false
 	}
 
@@ -732,10 +785,19 @@ func (h *Handler) extractAndValidateJWT(r *http.Request) (*auth.Claims, bool) {
 
 	claims, err := h.jwtValidator.ValidateToken(tokenString)
 	if err != nil {
-		log.Info("JWT validation failed", "error", err.Error())
+		log.Info("JWT validation failed",
+			"error", err.Error(),
+			"path", r.URL.Path,
+			"hint", "check KEYCLOAK_ISSUER_URL matches the 'iss' claim in the token")
 		return nil, false
 	}
 
+	if h.debugMode {
+		log.Info("[debug] JWT validated",
+			"user", claims.PreferredUsername,
+			"groups", claims.Groups,
+			"issuer", claims.Issuer)
+	}
 	return claims, true
 }
 
@@ -744,17 +806,18 @@ func (h *Handler) canAccessService(service *cache.ServiceInfo, authenticated boo
 	case "public":
 		return true
 
-	case "authenticated":
-		return authenticated
-
 	case "private":
+		// "private" requires authentication. When requiredGroups is empty the
+		// service is visible to any authenticated user; when groups are listed
+		// the caller must be a member of at least one of them.
 		if !authenticated {
 			return false
 		}
 		return h.hasRequiredGroups(claims.Groups, service.RequiredGroups)
 
 	default:
-		return authenticated
+		// Unknown / legacy visibility values default to private semantics.
+		return authenticated && h.hasRequiredGroups(claims.Groups, service.RequiredGroups)
 	}
 }
 
@@ -910,6 +973,132 @@ func (h *Handler) requireAuth(w http.ResponseWriter, r *http.Request) (*auth.Cla
 		return nil, false
 	}
 	return claims, true
+}
+
+// DebugRequestInfo is the request section of the debug response.
+type DebugRequestInfo struct {
+	Method  string            `json:"method"`
+	Path    string            `json:"path"`
+	Headers map[string]string `json:"headers"`
+}
+
+// DebugAuthInfo is the auth section of the debug response.
+type DebugAuthInfo struct {
+	Enabled             bool     `json:"enabled"`
+	ValidatorConfigured bool     `json:"validator_configured"`
+	Authenticated       bool     `json:"authenticated"`
+	Username            string   `json:"username,omitempty"`
+	Email               string   `json:"email,omitempty"`
+	Groups              []string `json:"groups,omitempty"`
+	ValidationError     string   `json:"validation_error,omitempty"`
+}
+
+// DebugServiceCounts is the service-cache section of the debug response.
+type DebugServiceCounts struct {
+	Total   int `json:"total_in_cache"`
+	Public  int `json:"visible_public"`
+	Private int `json:"visible_private"`
+	Hidden  int `json:"hidden_to_caller"`
+}
+
+// DebugResponse is the full body returned by GET /api/v1/debug.
+type DebugResponse struct {
+	Request  DebugRequestInfo   `json:"request"`
+	Auth     DebugAuthInfo      `json:"auth"`
+	Services DebugServiceCounts `json:"services"`
+}
+
+// handleDebug serves GET /api/v1/debug.
+// Only registered when the handler is created with WithDebugMode().
+// Returns request headers (with Bearer tokens redacted), resolved JWT claims,
+// and per-visibility service counts — similar to Keycloak's KC_HOSTNAME_DEBUG
+// page, but as JSON so it's queryable from scripts and kubectl port-forward.
+func (h *Handler) handleDebug(w http.ResponseWriter, r *http.Request) {
+	// Sanitise headers: redact Bearer tokens, keep everything else.
+	headers := make(map[string]string, len(r.Header))
+	for k, vals := range r.Header {
+		v := strings.Join(vals, ", ")
+		if strings.EqualFold(k, "Authorization") {
+			parts := strings.SplitN(v, " ", 2)
+			if len(parts) == 2 {
+				v = fmt.Sprintf("%s [REDACTED, %d bytes]", parts[0], len(parts[1]))
+			}
+		}
+		headers[k] = v
+	}
+
+	// Resolve auth state.
+	// When a claimsExtractor is configured (test / dev injection) or when the full
+	// JWT validator is available, extractAndValidateJWT already handles everything.
+	// For the debug response we also want to surface the validation *error* when
+	// the real validator is present, so we run the two paths in parallel.
+	claims, authenticated := h.extractAndValidateJWT(r)
+
+	authInfo := DebugAuthInfo{
+		Enabled:             h.enableAuth,
+		ValidatorConfigured: h.jwtValidator != nil || h.claimsExtractor != nil,
+	}
+
+	if authenticated && claims != nil {
+		authInfo.Authenticated = true
+		authInfo.Username = claims.PreferredUsername
+		authInfo.Email = claims.Email
+		authInfo.Groups = claims.Groups
+	} else {
+		// Provide a human-readable reason why authentication did not succeed.
+		switch {
+		case !h.enableAuth:
+			authInfo.ValidationError = "auth is disabled (ENABLE_AUTH=false)"
+		case h.jwtValidator == nil && h.claimsExtractor == nil:
+			authInfo.ValidationError = "JWT validator not configured (KEYCLOAK_URL missing?)"
+		default:
+			authHeader := r.Header.Get("Authorization")
+			if authHeader == "" {
+				authInfo.ValidationError = "no Authorization header present"
+			} else {
+				// Re-run validation to surface the actual error message.
+				parts := strings.Split(authHeader, " ")
+				if len(parts) != 2 || parts[0] != "Bearer" {
+					authInfo.ValidationError = "Authorization header is not in 'Bearer <token>' format"
+				} else if h.jwtValidator != nil {
+					if _, err := h.jwtValidator.ValidateToken(parts[1]); err != nil {
+						authInfo.ValidationError = err.Error()
+					}
+				}
+			}
+		}
+	}
+
+	// Count services per visibility for this caller.
+	counts := DebugServiceCounts{}
+	for _, svc := range h.cache.GetAll() {
+		counts.Total++
+		switch svc.Visibility {
+		case "public":
+			counts.Public++
+		default: // "private" and any legacy values
+			if h.canAccessService(svc, authenticated, claims) {
+				counts.Private++
+			} else {
+				counts.Hidden++
+			}
+		}
+	}
+
+	resp := DebugResponse{
+		Request: DebugRequestInfo{
+			Method:  r.Method,
+			Path:    r.URL.Path,
+			Headers: headers,
+		},
+		Auth:     authInfo,
+		Services: counts,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		log.Error(err, "Failed to encode debug response")
+	}
 }
 
 func corsMiddleware(allowedOrigins []string) func(http.Handler) http.Handler {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	sdapp "github.com/nebari-dev/nebari-landing/internal/app"
+	"github.com/nebari-dev/nebari-landing/internal/auth"
 	"github.com/nebari-dev/nebari-landing/internal/cache"
 )
 
@@ -139,8 +140,8 @@ func TestHandleGetServices_MethodNotAllowed(t *testing.T) {
 func TestHandleGetServices_AuthDisabled_OnlyPublicVisible(t *testing.T) {
 	sc := buildCache(
 		entry{"u1", "pub", "public", "", 0},
-		entry{"u2", "auth", "authenticated", "", 0},
-		entry{"u3", "priv", "private", "", 0},
+		entry{"u2", "priv1", "private", "", 0},
+		entry{"u3", "priv2", "private", "", 0},
 	)
 	rr := doGet(t, newTestHandler(sc).Routes(), "/api/v1/services")
 	if rr.Code != http.StatusOK {
@@ -161,7 +162,7 @@ func TestHandleGetServices_AuthDisabled_OnlyPublicVisible(t *testing.T) {
 func TestHandleGetServices_AuthEnabledNoToken_OnlyPublicVisible(t *testing.T) {
 	sc := buildCache(
 		entry{"u1", "pub", "public", "", 0},
-		entry{"u2", "auth", "authenticated", "", 0},
+		entry{"u2", "priv", "private", "", 0},
 	)
 	rr := doGet(t, newAuthTestHandler(sc).Routes(), "/api/v1/services")
 	if rr.Code != http.StatusOK {
@@ -176,7 +177,7 @@ func TestHandleGetServices_AuthEnabledNoToken_OnlyPublicVisible(t *testing.T) {
 	}
 }
 
-func TestHandleGetServices_DefaultVisibility_TreatedAsAuthenticated(t *testing.T) {
+func TestHandleGetServices_DefaultVisibility_TreatedAsPrivate(t *testing.T) {
 	sc := cache.NewServiceCache()
 	sc.Add(&sdapp.App{
 		UID:        "u-def",
@@ -186,7 +187,7 @@ func TestHandleGetServices_DefaultVisibility_TreatedAsAuthenticated(t *testing.T
 		TLSEnabled: true,
 		LandingPage: &sdapp.LandingPage{
 			Enabled:    true,
-			Visibility: "", // no Visibility → defaults to "authenticated"
+			Visibility: "", // no Visibility → defaults to "private"
 		},
 	})
 	rr := doGet(t, newTestHandler(sc).Routes(), "/api/v1/services")
@@ -194,7 +195,7 @@ func TestHandleGetServices_DefaultVisibility_TreatedAsAuthenticated(t *testing.T
 	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
 		t.Fatal(err)
 	}
-	// auth disabled + default visibility → service is not shown to unauthenticated callers
+	// auth disabled + default visibility (private) → service not shown to unauthenticated callers
 	if len(resp.Services) != 0 {
 		t.Errorf("expected 0 services without token, got %d", len(resp.Services))
 	}
@@ -266,9 +267,9 @@ func TestHandleGetServiceByUID_PublicAccess_NoAuth(t *testing.T) {
 	}
 }
 
-func TestHandleGetServiceByUID_AuthenticatedService_Forbidden_NoAuth(t *testing.T) {
-	sc := buildCache(entry{"uid-auth", "auth-svc", "authenticated", "", 0})
-	rr := doGet(t, newTestHandler(sc).Routes(), "/api/v1/services/uid-auth")
+func TestHandleGetServiceByUID_PrivateService_Forbidden_NoAuth_NoValidator(t *testing.T) {
+	sc := buildCache(entry{"uid-priv2", "priv-svc2", "private", "", 0})
+	rr := doGet(t, newTestHandler(sc).Routes(), "/api/v1/services/uid-priv2")
 	if rr.Code != http.StatusForbidden {
 		t.Errorf("expected 403, got %d", rr.Code)
 	}
@@ -413,7 +414,7 @@ func TestHandleCallerIdentity_MethodNotAllowed(t *testing.T) {
 func TestHandleGetServices_InvalidAuthHeader_TreatedAsUnauthenticated(t *testing.T) {
 	sc := buildCache(
 		entry{"u1", "pub", "public", "", 0},
-		entry{"u2", "auth", "authenticated", "", 0},
+		entry{"u2", "priv", "private", "", 0},
 	)
 	rr := doGet(t, newAuthTestHandler(sc).Routes(), "/api/v1/services",
 		"Authorization", "NotBearer sometoken",
@@ -449,11 +450,197 @@ func TestHandleGetNotifications_ReturnsEmptyList(t *testing.T) {
 	}
 }
 
-func TestHandleGetNotifications_MethodNotAllowed(t *testing.T) {
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/notifications", nil)
-	rr := httptest.NewRecorder()
-	newTestHandler(cache.NewServiceCache()).Routes().ServeHTTP(rr, req)
-	if rr.Code != http.StatusMethodNotAllowed {
-		t.Errorf("expected 405, got %d", rr.Code)
+// newHandlerWithClaims returns a Handler with auth enabled and claims injection
+// via WithClaimsExtractor. This simulates an authenticated request without
+// requiring a real Keycloak instance or a signed JWT.
+func newHandlerWithClaims(sc *cache.ServiceCache, claims *auth.Claims) *Handler {
+	return NewHandler(sc, nil, true, nil, nil,
+		WithClaimsExtractor(func(_ *http.Request) (*auth.Claims, bool) {
+			return claims, true
+		}),
+	)
+}
+
+// --- authenticated service access ---
+
+func TestHandleGetServices_AuthenticatedUser_SeesPublicAndOpenPrivate(t *testing.T) {
+	// Build a cache with the 2-tier model:
+	//   public   → everyone
+	//   private (no groups) → any authenticated user
+	//   private (admin group) → admin only; alice (viewer) cannot see it
+	sc := cache.NewServiceCache()
+	sc.Add(&sdapp.App{
+		UID: "u1", Name: "pub", Namespace: "ns",
+		Hostname: "pub.example.com", TLSEnabled: true,
+		LandingPage: &sdapp.LandingPage{Enabled: true, Visibility: "public"},
+	})
+	sc.Add(&sdapp.App{
+		UID: "u2", Name: "jupyter", Namespace: "ns",
+		Hostname: "jupyter.example.com", TLSEnabled: true,
+		LandingPage: &sdapp.LandingPage{
+			Enabled: true, Visibility: "private",
+			// no RequiredGroups → any authenticated user
+		},
+	})
+	sc.Add(&sdapp.App{
+		UID: "u3", Name: "admin-panel", Namespace: "ns",
+		Hostname: "admin.example.com", TLSEnabled: true,
+		LandingPage: &sdapp.LandingPage{
+			Enabled: true, Visibility: "private",
+			RequiredGroups: []string{"admin"}, // alice (viewer) is not in this group
+		},
+	})
+	claims := &auth.Claims{PreferredUsername: "alice", Groups: []string{"viewer"}}
+	rr := doGet(t, newHandlerWithClaims(sc, claims).Routes(), "/api/v1/services")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var resp ServiceResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	// alice sees: public (u1) + private-no-groups (u2) = 2; admin-panel is hidden.
+	if len(resp.Services) != 2 {
+		t.Errorf("expected 2 services (public + open-private), got %d", len(resp.Services))
+	}
+	var ids []string
+	for _, s := range resp.Services {
+		ids = append(ids, s.ID)
+	}
+	for _, want := range []string{"u1", "u2"} {
+		found := false
+		for _, id := range ids {
+			if id == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected service %q in response, got %v", want, ids)
+		}
+	}
+}
+
+func TestHandleGetServices_AdminUser_SeesPrivateServices(t *testing.T) {
+	sc := cache.NewServiceCache()
+	sc.Add(&sdapp.App{
+		UID: "u-priv", Name: "secret-tool", Namespace: "ns",
+		Hostname: "secret.example.com", TLSEnabled: true,
+		LandingPage: &sdapp.LandingPage{
+			Enabled: true, Visibility: "private",
+			RequiredGroups: []string{"admin"},
+		},
+	})
+	sc.Add(&sdapp.App{
+		UID: "u-pub", Name: "public-tool", Namespace: "ns",
+		Hostname: "pub.example.com", TLSEnabled: true,
+		LandingPage: &sdapp.LandingPage{Enabled: true, Visibility: "public"},
+	})
+
+	adminClaims := &auth.Claims{PreferredUsername: "admin", Groups: []string{"admin"}}
+	rr := doGet(t, newHandlerWithClaims(sc, adminClaims).Routes(), "/api/v1/services")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var resp ServiceResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Services) != 2 {
+		t.Errorf("expected 2 services for admin (public+private), got %d", len(resp.Services))
+	}
+}
+
+func TestHandleGetServices_NonAdminUser_CannotSeePrivateService(t *testing.T) {
+	sc := cache.NewServiceCache()
+	sc.Add(&sdapp.App{
+		UID: "u-priv", Name: "secret-tool", Namespace: "ns",
+		Hostname: "secret.example.com", TLSEnabled: true,
+		LandingPage: &sdapp.LandingPage{
+			Enabled: true, Visibility: "private",
+			RequiredGroups: []string{"admin"},
+		},
+	})
+	sc.Add(&sdapp.App{
+		UID: "u-pub", Name: "public-tool", Namespace: "ns",
+		Hostname: "pub.example.com", TLSEnabled: true,
+		LandingPage: &sdapp.LandingPage{Enabled: true, Visibility: "public"},
+	})
+
+	userClaims := &auth.Claims{PreferredUsername: "alice", Groups: []string{"viewer"}}
+	rr := doGet(t, newHandlerWithClaims(sc, userClaims).Routes(), "/api/v1/services")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var resp ServiceResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Services) != 1 {
+		t.Errorf("expected 1 service (public only) for non-admin, got %d", len(resp.Services))
+	}
+	if len(resp.Services) > 0 && resp.Services[0].ID != "u-pub" {
+		t.Errorf("expected public service, got %q", resp.Services[0].ID)
+	}
+}
+
+func TestHandleGetServiceByUID_PrivateService_AllowedWithToken(t *testing.T) {
+	// private with no requiredGroups → any authenticated user can access it
+	sc := buildCache(entry{"uid-priv-open", "jupyter", "private", "", 0})
+	claims := &auth.Claims{PreferredUsername: "alice"}
+	rr := doGet(t, newHandlerWithClaims(sc, claims).Routes(), "/api/v1/services/uid-priv-open")
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200 for authenticated user on open-private service, got %d", rr.Code)
+	}
+}
+
+func TestHandleDebug_OnlyRegisteredWhenDebugModeEnabled(t *testing.T) {
+	// Without debug mode: /api/v1/debug returns 404.
+	rr := doGet(t, newTestHandler(cache.NewServiceCache()).Routes(), "/api/v1/debug")
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 without debug mode, got %d", rr.Code)
+	}
+
+	// With debug mode: the endpoint is registered and returns 200.
+	h := NewHandler(cache.NewServiceCache(), nil, false, nil, nil, WithDebugMode())
+	rr = doGet(t, h.Routes(), "/api/v1/debug")
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200 with debug mode, got %d", rr.Code)
+	}
+	var body DebugResponse
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode debug response: %v", err)
+	}
+	if body.Auth.Enabled {
+		t.Error("expected auth.enabled=false")
+	}
+}
+
+func TestHandleDebug_AuthenticatedUser_ShowsClaims(t *testing.T) {
+	sc := buildCache(
+		entry{"u1", "pub", "public", "", 0},
+		entry{"u2", "priv-open", "private", "", 0},
+	)
+	claims := &auth.Claims{PreferredUsername: "alice", Email: "alice@example.com", Groups: []string{"devs"}}
+	h := NewHandler(sc, nil, true, nil, nil,
+		WithDebugMode(),
+		WithClaimsExtractor(func(_ *http.Request) (*auth.Claims, bool) {
+			return claims, true
+		}),
+	)
+	rr := doGet(t, h.Routes(), "/api/v1/debug")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var body DebugResponse
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode debug response: %v", err)
+	}
+	if body.Services.Public != 1 {
+		t.Errorf("expected 1 public service, got %d", body.Services.Public)
+	}
+	// alice is authenticated; the "auth" service has no requiredGroups so it
+	// shows up in Services.Private (any-authenticated-user private service).
+	if body.Services.Private != 1 {
+		t.Errorf("expected 1 private (open) service, got %d", body.Services.Private)
 	}
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -55,7 +55,12 @@ type LandingPage struct {
 	Priority int
 
 	// Visibility controls who can see this service.
-	// Valid values: "public", "authenticated" (default), "private".
+	// Valid values:
+	//   "public"  — visible to all users, no authentication required.
+	//   "private" — visible only to authenticated users who are a member of at
+	//               least one group listed in RequiredGroups. When RequiredGroups
+	//               is empty, any authenticated user can see the service.
+	// Default (when unset): "private".
 	Visibility string
 
 	// RequiredGroups lists Keycloak groups required when Visibility is "private".

--- a/internal/cache/service_cache.go
+++ b/internal/cache/service_cache.go
@@ -60,7 +60,7 @@ func (c *ServiceCache) Add(a *sdapp.App) {
 	if lp.Priority != 0 {
 		priority = lp.Priority
 	}
-	visibility := "authenticated"
+	visibility := "private"
 	if lp.Visibility != "" {
 		visibility = lp.Visibility
 	}

--- a/internal/keycloak/client.go
+++ b/internal/keycloak/client.go
@@ -132,14 +132,23 @@ func NewFromEnvWithK8sClient(ctx context.Context, k8sClient client.Client) (*Cli
 				user = string(u)
 			} else if u, ok := secret.Data["admin-username"]; ok {
 				user = string(u)
+			} else if user != "" {
+				// Secret has no username key; keep the value from KEYCLOAK_ADMIN_USERNAME.
+				log.Info("Keycloak admin secret has no 'username'/'admin-username' key — using KEYCLOAK_ADMIN_USERNAME",
+					"secret", secretName, "namespace", secretNS)
+			} else {
+				log.Info("Keycloak admin secret has no username key and KEYCLOAK_ADMIN_USERNAME is unset; add a 'username' key to the secret",
+					"secret", secretName, "namespace", secretNS)
 			}
 			if p, ok := secret.Data["password"]; ok {
 				pass = string(p)
 			} else if p, ok := secret.Data["admin-password"]; ok {
 				pass = string(p)
 			}
-			log.Info("Loaded Keycloak admin credentials from Kubernetes secret",
-				"secret", secretName, "namespace", secretNS)
+			if user != "" && pass != "" {
+				log.Info("Loaded Keycloak admin credentials from Kubernetes secret",
+					"secret", secretName, "namespace", secretNS)
+			}
 		} else {
 			log.Error(err, "Failed to read Keycloak admin secret; falling back to env vars",
 				"secret", secretName, "namespace", secretNS)


### PR DESCRIPTION
- Simplify visibility model to public/private only (remove 'authenticated' tier)
  - canAccessService: 2-tier logic in handlers.go
  - Default visibility changed from 'authenticated' to 'private' in service_cache.go
  - Update app.go comment, test-nebariapps.yaml, handlers_test.go accordingly

- Fix frontend OIDC auth chain
  - keycloak.ts: PKCE S256 login-required flow with token refresh
  - client.ts: apiFetch() attaches Authorization: Bearer header
  - main.tsx: path-based routing, public route skips Keycloak init
  - user.ts: typed user profile helpers
  - config.json: clientId set to nebari-frontend-spa

- Fix Keycloak client provisioning (dev)
  - frontend-client-job.yaml: rewrite; was a duplicate spec bug preventing nebari-frontend-spa (public PKCE client) from ever being created
  - dev/Makefile: postgresql-secrets target adds username=admin and password=REALM_ADMIN_PASSWORD to nebari-realm-admin-credentials secret

- Fix webapi Keycloak admin client credential loading
  - keycloak/client.go: defer success log until both username and password confirmed present; add warning when username key is missing in secret

- Add debug endpoint and debug mode infrastructure
  - cmd/main.go, app.go: DEBUG_MODE env var support
  - handlers.go: /api/v1/debug endpoint (claims, service counts, cache state)
  - chart values: webapi.debugMode flag wired to DEBUG_MODE env var

- Dev environment fixes
  - dev/nginx.conf: add /api/ proxy block with Authorization header forwarding
  - dev/webapi_test.py: update for flat list response format and 2-tier visibility
  - dev/Dockerfile: improvements for local dev image
  - keycloak/nebari-realm.json: realm config updates