### PR TITLE
feat(chart): make NebariApp gateway explicit (public) for frontend and webapi

### DIFF
--- a/charts/nebari-landing/templates/nebariapp.yaml
+++ b/charts/nebari-landing/templates/nebariapp.yaml
@@ -15,6 +15,12 @@ metadata:
 spec:
   hostname: {{ $host | quote }}
 
+  # Public gateway — the oauth2-proxy sidecar in the frontend pod handles auth;
+  # no SecurityPolicy is created at the gateway level. Once nebari-operator#61
+  # is resolved and oauth2-proxy becomes optional, this can switch to gateway-level
+  # OIDC enforcement via EnforceAtGateway.
+  gateway: public
+
   service:
     name: {{ include "nebari-landing.fullname" . }}-frontend
     port: {{ .Values.frontend.service.port }}
@@ -58,6 +64,9 @@ metadata:
     app.kubernetes.io/component: webapi
 spec:
   hostname: {{ $host | quote }}
+
+  # Public gateway — JWT validation is handled in-process by the webapi.
+  gateway: public
 
   service:
     name: {{ include "nebari-landing.fullname" . }}-webapi


### PR DESCRIPTION
## Description

Adds an explicit `gateway: public` field to both `NebariApp` CRs defined in the `nebariapp.yaml` chart template, instead of relying on the kubebuilder default value.

### Why

The `NebariApp` spec has `gateway` as an optional field with a `+kubebuilder:default=public` marker. While the default is `public`, making it explicit:

1. Makes the intent clear in the rendered manifest — reviewers don't need to look up the CRD defaults to understand which gateway is used.
2. Prevents surprises if the default ever changes in a future operator version.
3. Adds an explanatory comment documenting the oauth2-proxy architecture and the planned migration path.

### Architecture note

**Frontend NebariApp** (`/oauth2/*` + `/*` → oauth2-proxy sidecar):
- `auth.enabled: false` / `enforceAtGateway: false` — the Gateway passes traffic straight through to the pod.
- The oauth2-proxy sidecar in the frontend pod intercepts every request and enforces Keycloak login before proxying to the nginx static server.

**Webapi NebariApp** (`/api/*` → Go webapi):
- `auth.enabled: false` / `enforceAtGateway: false` — no SecurityPolicy created.
- The webapi validates Bearer tokens in-process via its JWT validator.

### Future migration path

Once [nebari-operator#61](https://github.com/nebari-dev/nebari-operator/pull/61) is resolved, the oauth2-proxy sidecar can be made optional. At that point this chart can switch the frontend NebariApp to `auth.enabled: true, enforceAtGateway: true`, moving OIDC enforcement to the Envoy Gateway level natively.

## Changes

- `charts/nebari-landing/templates/nebariapp.yaml`: add `gateway: public` + comments to both NebariApp resources

## Testing

- Render the chart with `helm template` and confirm both NebariApp resources include `gateway: public`:
  ```sh
  helm template nebari-landing charts/nebari-landing     --set nebariApp.enabled=true     --set httpRoute.hostname=nebari.example.com     | grep -A2 'kind: NebariApp'
  ```