### PR TITLE
fix(chart): wire oauth2-proxy secrets to operator-created secret names

### DIFF
--- a/charts/nebari-landing/templates/NOTES.txt
+++ b/charts/nebari-landing/templates/NOTES.txt
@@ -19,9 +19,16 @@ Pre-requisites to verify before using:
   1. Keycloak OIDC client "{{ .Values.frontend.oauth2Proxy.clientId }}" exists in realm {{ .Values.webapi.keycloak.realm }}
      with redirect URI: {{ if .Values.httpRoute.tls }}https{{ else }}http{{ end }}://{{ .Values.httpRoute.hostname }}/oauth2/callback
 
-  2. Secret "{{ .Values.frontend.oauth2Proxy.existingSecret }}" exists in namespace {{ .Release.Namespace }}
-     with keys: client-secret, cookie-secret
-     (generate cookie-secret: openssl rand -base64 32 | tr -d '\n')
+  2. OIDC client-secret: the nebari-operator creates
+     "{{ default (printf "%s-oidc-client" (include "nebari-landing.fullname" .)) .Values.frontend.oauth2Proxy.existingClientSecret }}"
+     automatically in namespace {{ .Release.Namespace }} when it reconciles the
+     frontend NebariApp. No manual action required.
 
-  3. Keycloak admin secret "{{ .Values.webapi.keycloak.adminSecretName }}" exists in
+  3. Cookie-secret: the chart auto-generates
+     "{{ default (printf "%s-oauth2-proxy-cookie" (include "nebari-landing.fullname" .)) .Values.frontend.oauth2Proxy.existingCookieSecret }}"
+     in namespace {{ .Release.Namespace }} on first install and preserves the
+     value across upgrades (helm.sh/resource-policy: keep).
+     To use your own: set frontend.oauth2Proxy.existingCookieSecret.
+
+  4. Keycloak admin secret "{{ .Values.webapi.keycloak.adminSecretName }}" exists in
      namespace "{{ .Values.webapi.keycloak.adminSecretNamespace }}" with keys: username, password

--- a/charts/nebari-landing/templates/frontend/deployment.yaml
+++ b/charts/nebari-landing/templates/frontend/deployment.yaml
@@ -95,12 +95,12 @@ spec:
             - name: OAUTH2_PROXY_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "frontend.oauth2Proxy.existingSecret is required" .Values.frontend.oauth2Proxy.existingSecret }}
-                  key: client-secret
+                  name: {{ default (printf "%s-oidc-client" (include "nebari-landing.fullname" .)) .Values.frontend.oauth2Proxy.existingClientSecret }}
+                  key: {{ default "client-secret" .Values.frontend.oauth2Proxy.clientSecretKey }}
             - name: OAUTH2_PROXY_COOKIE_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.frontend.oauth2Proxy.existingSecret }}
+                  name: {{ default (printf "%s-oauth2-proxy-cookie" (include "nebari-landing.fullname" .)) .Values.frontend.oauth2Proxy.existingCookieSecret }}
                   key: cookie-secret
           ports:
             - name: proxy

--- a/charts/nebari-landing/templates/frontend/oauth2-proxy-cookie-secret.yaml
+++ b/charts/nebari-landing/templates/frontend/oauth2-proxy-cookie-secret.yaml
@@ -1,0 +1,29 @@
+{{- /*
+Generate a stable random cookie-secret for the oauth2-proxy sidecar when the
+operator has not pre-created one.
+
+The Helm `lookup` function reads the existing Secret on upgrades so the cookie
+value is preserved across deployments (preventing all users from being logged
+out on every helm upgrade). On the very first install, `lookup` returns nil and
+Helm generates a fresh 32-byte random value.
+
+If `existingCookieSecret` is set the chart assumes the operator/admin manages
+the secret externally and renders nothing here.
+*/}}
+{{- if not .Values.frontend.oauth2Proxy.existingCookieSecret }}
+{{- $secretName := printf "%s-oauth2-proxy-cookie" (include "nebari-landing.fullname" .) }}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "nebari-landing.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
+type: Opaque
+data:
+  # Preserved across upgrades via lookup; generated fresh on first install.
+  cookie-secret: {{ if $existing }}{{ index $existing.data "cookie-secret" }}{{ else }}{{ randBytes 32 | b64enc }}{{ end }}
+{{- end }}

--- a/charts/nebari-landing/values.yaml
+++ b/charts/nebari-landing/values.yaml
@@ -60,10 +60,22 @@ frontend:
     # Keycloak OIDC client ID registered for the landing page frontend.
     clientId: "nebari-landing"
 
-    # Name of a Kubernetes Secret containing:
-    #   client-secret  — OIDC client secret
-    #   cookie-secret  — 32-byte random base64 string (openssl rand -base64 32)
-    existingSecret: "nebari-landing-oauth2-proxy"
+    # Name of the Secret containing the OIDC client-secret key.
+    # The nebari-operator creates this automatically when it reconciles the
+    # frontend NebariApp: it follows the pattern <nebariapp-name>-oidc-client.
+    # Leave empty to use the operator-created default derived from the chart
+    # fullname: "<fullname>-oidc-client".
+    existingClientSecret: ""
+
+    # Key inside existingClientSecret that holds the OIDC client secret value.
+    clientSecretKey: "client-secret"
+
+    # Name of a Secret containing a 'cookie-secret' key (32-byte random base64
+    # string used by oauth2-proxy to encrypt session cookies).
+    # Leave empty to let the chart generate and manage this secret automatically.
+    # The auto-generated secret is stable across upgrades (uses Helm lookup to
+    # preserve the existing value rather than re-rolling on each helm upgrade).
+    existingCookieSecret: ""
 
     # If true the access token is forwarded to the upstream (webapi calls from
     # the browser will arrive pre-authorised).


### PR DESCRIPTION
## Problem

The chart had a single `existingSecret` value (defaulting to `nebari-landing-oauth2-proxy`) that was expected to contain **both**:
- `client-secret` — the Keycloak OIDC client secret
- `cookie-secret` — the oauth2-proxy session cookie encryption key

This was broken in two ways:

1. **Wrong secret name**: the nebari-operator creates the OIDC client secret as `<nebariapp-name>-oidc-client` (e.g. `nebari-landing-oidc-client`), not `nebari-landing-oauth2-proxy`. The operator writes a single key: `client-secret`.

2. **No cookie-secret**: the chart had no way to create the cookie-secret — it had to be manually pre-created before install, which broke automated GitOps deployments.

## Solution

Split into two independent secret references:

### OIDC client secret (operator-managed)
- New value: `frontend.oauth2Proxy.existingClientSecret`
- Default: `<fullname>-oidc-client` — matches the operator naming convention `<nebariapp-name>-oidc-client`
- No chart action required; the operator creates and owns this secret

### Cookie secret (chart-managed)
- New value: `frontend.oauth2Proxy.existingCookieSecret`
- Default: chart auto-generates `<fullname>-oauth2-proxy-cookie` on first install
- Uses Helm `lookup` to preserve the value across upgrades (no session invalidation)
- `helm.sh/resource-policy: keep` prevents accidental deletion on `helm uninstall`
- Set `existingCookieSecret` to BYO an externally managed secret

## Changes

| File | Change |
|---|---|
| `values.yaml` | `existingSecret` → `existingClientSecret` + `existingCookieSecret` |
| `templates/frontend/deployment.yaml` | Two independent `secretKeyRef` entries |
| `templates/frontend/oauth2-proxy-cookie-secret.yaml` | New: stable auto-generated cookie secret |
| `templates/NOTES.txt` | Updated pre-requisites — items 2 & 3 are now automatic |