### PR TITLE
feat(release): improve release workflow and add contributor docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@
 #   manifest-webapi   — stitch arch images → semver-tagged manifest
 #   manifest-frontend — stitch arch images → semver-tagged manifest
 #   publish-chart     — package and attach Helm chart to the GitHub release
+#   sync-helm-repository — open a PR in nebari-dev/helm-repository with the new chart
 
 name: Release
 
@@ -307,8 +308,10 @@ jobs:
           # Patch Chart.yaml version and appVersion
           sed -i "s/^version:.*/version: ${VERSION}/" charts/nebari-landing/Chart.yaml
           sed -i "s/^appVersion:.*/appVersion: \"${GITHUB_REF_NAME}\"/" charts/nebari-landing/Chart.yaml
-          # Pin image tags in values.yaml so the packaged chart references this release
-          sed -i "s|tag: \"latest\"|tag: \"${GITHUB_REF_NAME}\"|g" charts/nebari-landing/values.yaml
+          # Pin image tags in values.yaml so the packaged chart references this release.
+          # Matches any quoted tag value (idempotent: works whether values.yaml has "latest"
+          # or a previous version, e.g. if prepare-release was run locally before CI).
+          sed -i "s|tag: \"[^\"]*\"|tag: \"${GITHUB_REF_NAME}\"|g" charts/nebari-landing/values.yaml
 
       - name: Package Helm chart
         run: |
@@ -333,3 +336,59 @@ jobs:
           echo "**Helm chart:** \`nebari-landing-${VERSION}.tgz\`" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Platforms**: linux/amd64, linux/arm64" >> "$GITHUB_STEP_SUMMARY"
+
+  # ── Sync Helm chart to helm-repository ────────────────────────────────────
+  sync-helm-repository:
+    name: Sync chart to helm-repository
+    runs-on: ubuntu-latest
+    needs: publish-chart
+    steps:
+      - name: Checkout helm-repository
+        uses: actions/checkout@v4
+        with:
+          repository: nebari-dev/helm-repository
+          token: ${{ secrets.NEBARI_BOT_TOKEN }}
+          path: helm-repository
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Download chart from release
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          CHART_URL="https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/nebari-landing-${VERSION}.tgz"
+          echo "Downloading chart from: $CHART_URL"
+          curl -fsSL -o "helm-repository/charts/nebari-landing-${VERSION}.tgz" "$CHART_URL"
+
+      - name: Update Helm repository index
+        run: |
+          cd helm-repository
+          helm repo index charts --url https://nebari-dev.github.io/helm-repository/charts --merge charts/index.yaml
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.NEBARI_BOT_TOKEN }}
+          path: helm-repository
+          commit-message: "feat: add nebari-landing ${{ github.event.release.tag_name }}"
+          branch: add-nebari-landing-${{ github.event.release.tag_name }}
+          title: "feat: add nebari-landing ${{ github.event.release.tag_name }}"
+          body: |
+            Automated PR from nebari-landing release workflow.
+
+            ## Changes
+            - Added `nebari-landing-${{ github.event.release.tag_name }}.tgz`
+            - Updated Helm repository index
+
+            ## Source
+            Release: ${{ github.event.release.html_url }}
+
+            ## Testing
+            ```bash
+            helm repo add nebari-dev https://nebari-dev.github.io/helm-repository
+            helm repo update
+            helm search repo nebari-landing --versions
+            ```
+          labels: |
+            automated
+            release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,234 @@
+# Contributing to Nebari Landing
+
+Thank you for your interest in contributing! This guide will help you get started with development.
+
+## Development Workflow
+
+### Prerequisites
+
+- Go 1.23 or later
+- Node.js 22+ (see `frontend/.node-version`)
+- Docker or Podman (for building images)
+- Kubernetes cluster (kind, k3d, minikube, or cloud provider)
+- `kubectl` configured to access your cluster
+- Nebari Operator installed in your cluster (for NebariApp CRD)
+
+### Setup
+
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/nebari-dev/nebari-landing.git
+   cd nebari-landing
+   ```
+
+2. **Install dependencies**
+   ```bash
+   go mod download
+   cd frontend && npm ci && cd ..
+   ```
+
+3. **Verify your setup**
+   ```bash
+   make test  # Run backend unit tests
+   cd frontend && npm run lint && npm run build && cd ..  # Verify frontend
+   ```
+
+## Making Changes
+
+### Modifying the Backend (webapi)
+
+When adding or changing backend functionality:
+
+1. **Make your changes** to Go code in `internal/` or `cmd/`
+2. **Run tests and linting**:
+   ```bash
+   make fmt vet test
+   ```
+
+3. **Test locally** (see Local Development section below)
+
+4. **Commit**:
+   ```bash
+   git add internal/ cmd/
+   git commit -m "feat: add new endpoint"
+   ```
+
+### Modifying the Frontend
+
+When changing the React UI:
+
+1. **Make your changes** in `frontend/src/`
+2. **Run linting and build**:
+   ```bash
+   cd frontend
+   npm run lint
+   npm run build
+   cd ..
+   ```
+
+3. **Test locally** (see Local Development section below)
+
+4. **Commit**:
+   ```bash
+   git add frontend/
+   git commit -m "feat: improve service card UI"
+   ```
+
+### Modifying the Helm Chart
+
+When updating deployment configuration:
+
+1. **Make your changes** in `charts/nebari-landing/`
+2. **Test locally**:
+   ```bash
+   helm template charts/nebari-landing/ | kubectl apply --dry-run=client -f -
+   ```
+
+3. **Commit**:
+   ```bash
+   git add charts/
+   git commit -m "fix: update resource limits"
+   ```
+
+**Note**: Chart versioning is handled during releases. Don't manually update `Chart.yaml` versions.
+
+## Local Development
+
+### Running Locally with Docker Compose
+
+The fastest way to develop is using the local dev environment:
+
+```bash
+cd dev
+make setup    # Start Kind cluster with operator
+make up       # Start webapi + frontend + Redis
+```
+
+See [dev/QUICKSTART.md](dev/QUICKSTART.md) for detailed instructions.
+
+### Running Backend Only
+
+To run just the webapi against your cluster:
+
+```bash
+# Ensure you have NebariApp CRDs and a service account
+make deploy
+
+# Or run locally (watches your cluster)
+go run ./cmd/main.go
+```
+
+### Running Frontend in Development Mode
+
+```bash
+cd frontend
+npm run dev  # Starts Vite dev server on http://localhost:5173
+```
+
+**Note**: The frontend expects the webapi at `http://localhost:8080` by default.
+
+### Testing in a Kind Cluster
+
+Build and deploy both components:
+
+```bash
+make dev  # Builds image, loads to Kind, deploys to nebari-system
+```
+
+Port-forward to access:
+
+```bash
+make pf  # Forwards webapi to localhost:8080
+```
+
+## Pull Request Process
+
+1. **Create a feature branch**:
+   ```bash
+   git checkout -b feat/my-feature
+   ```
+
+2. **Make your changes** following the guidelines above
+
+3. **Ensure tests pass**:
+   ```bash
+   make test
+   cd frontend && npm run lint && npm run build && cd ..
+   ```
+
+4. **Push and create PR**:
+   ```bash
+   git push origin feat/my-feature
+   ```
+   Then open a PR on GitHub.
+
+5. **CI Checks**: Your PR must pass:
+   - ✅ Backend tests and linting (Go)
+   - ✅ Frontend linting and build (ESLint, Vite)
+   - ✅ Docker image builds successfully
+
+## Common Tasks
+
+### Adding a New WebAPI Endpoint
+
+1. Add handler in `internal/handlers/`
+2. Register route in `internal/server/server.go`
+3. Add tests in `internal/handlers/*_test.go`
+4. Update API documentation in `docs/api.md`
+
+### Adding a New Frontend Component
+
+1. Create component in `frontend/src/components/`
+2. Follow USWDS design system patterns
+3. Ensure TypeScript types are correct
+4. Test responsiveness
+
+### Updating Dependencies
+
+**Backend**:
+```bash
+go get -u ./...
+go mod tidy
+```
+
+**Frontend**:
+```bash
+cd frontend
+npm update
+npm audit fix
+cd ..
+```
+
+## Debugging
+
+**Enable debug logging** for webapi:
+```bash
+kubectl set env deployment/webapi \
+  LOG_LEVEL=debug \
+  -n nebari-system
+```
+
+**Check webapi logs**:
+```bash
+kubectl logs -f deployment/webapi -c api -n nebari-system
+```
+
+**Frontend dev tools**: Use browser DevTools → Network tab to inspect API calls.
+
+## Code Style
+
+- **Go**: Run `make fmt vet` before committing
+- **TypeScript/React**: Use `npm run lint` to check style
+- Follow existing patterns in the codebase
+- Write clear commit messages (conventional commits preferred)
+
+## Release Process
+
+Releases are automated. See [docs/maintainers/release-checklist.md](docs/maintainers/release-checklist.md) for maintainer instructions.
+
+## Getting Help
+
+- **Documentation**: See [README.md](README.md) and [docs/](docs/)
+- **Local dev guide**: [dev/QUICKSTART.md](dev/QUICKSTART.md)
+- **API reference**: [docs/api.md](docs/api.md)
+- **Issues**: Open an issue on GitHub for bugs or feature requests

--- a/Makefile
+++ b/Makefile
@@ -93,3 +93,57 @@ dev: ## Build image, load into Kind, and deploy for local testing.
 .PHONY: pf
 pf: ## Port-forward the webapi to localhost:8080.
 	kubectl port-forward -n nebari-system svc/webapi 8080:8080
+
+##@ Helm Chart
+
+CHART_DIR := charts/nebari-landing
+
+.PHONY: helm-package
+helm-package: ## Package the Helm chart (requires Helm).
+	@echo "📦 Packaging Helm chart..."
+	@mkdir -p dist
+	helm package $(CHART_DIR) --destination dist/
+	@echo "✅ Chart packaged to dist/"
+
+.PHONY: helm-chart-version
+helm-chart-version: ## Update Helm chart version and appVersion (requires VERSION and APP_VERSION vars).
+	@if [ -z "$(VERSION)" ] || [ -z "$(APP_VERSION)" ]; then \
+		echo "❌ Error: VERSION and APP_VERSION are required"; \
+		echo "   Usage: make helm-chart-version VERSION=0.2.0 APP_VERSION=v0.2.0"; \
+		exit 1; \
+	fi
+	@echo "⎈  Updating chart version to $(VERSION), appVersion to $(APP_VERSION)..."
+	@sed -i 's/^version:.*/version: $(VERSION)/' $(CHART_DIR)/Chart.yaml
+	@sed -i 's/^appVersion:.*/appVersion: "$(APP_VERSION)"/' $(CHART_DIR)/Chart.yaml
+	@echo "✅ Chart versions updated"
+	@echo "   Note: values.yaml image tags are pinned by CI at release time; do not commit them."
+
+##@ Release
+
+.PHONY: prepare-release
+prepare-release: ## Prepare release artifacts (must be on a release tag)
+	@if ! git describe --exact-match --tags HEAD 2>/dev/null; then \
+		echo "❌ Error: Not on a release tag. Create and checkout tag first."; \
+		echo "   Example: git tag v0.2.0 && git checkout v0.2.0"; \
+		exit 1; \
+	fi
+	@TAG=$$(git describe --exact-match --tags HEAD); \
+	VERSION="$${TAG#v}"; \
+	echo "📦 Preparing release artifacts for $$TAG..."; \
+	echo ""; \
+	echo "1️⃣  Updating Helm chart versions..."; \
+	$(MAKE) helm-chart-version VERSION="$$VERSION" APP_VERSION="$$TAG"; \
+	echo ""; \
+	echo "2️⃣  Packaging Helm chart..."; \
+	$(MAKE) helm-package; \
+	echo ""; \
+	echo "3️⃣  Staging Chart.yaml for commit (values.yaml tag stays 'latest' — CI pins it)..."; \
+	git add $(CHART_DIR)/Chart.yaml; \
+	echo ""; \
+	echo "✅ Release artifacts prepared for $$TAG"; \
+	echo ""; \
+	echo "Next steps:"; \
+	echo "  1. Review changes: git status && git diff --cached"; \
+	echo "  2. Commit: git commit -m 'chore: prepare chart for $$TAG'"; \
+	echo "  3. Push tag: git push origin $$TAG"; \
+	echo "  4. Publish the GitHub release to trigger CI"

--- a/README.md
+++ b/README.md
@@ -202,6 +202,11 @@ make test
 make -f dev/Makefile up
 ```
 
+**Documentation**:
+- **[Contributing Guide](CONTRIBUTING.md)** - Complete development workflow
+- **[Release Checklist](docs/maintainers/release-checklist.md)** - For maintainers creating releases
+- **[API Reference](docs/api.md)** - WebAPI endpoint documentation
+
 See our [issue tracker](https://github.com/nebari-dev/nebari-landing/issues) for open issues.
 
 ## License

--- a/docs/maintainers/release-checklist.md
+++ b/docs/maintainers/release-checklist.md
@@ -1,0 +1,208 @@
+# Nebari Landing Release Checklist
+
+This document provides step-by-step instructions for creating a new release of nebari-landing.
+
+## Prerequisites
+
+- [ ] Push access to `nebari-dev/nebari-landing`
+- [ ] Write access to create GitHub releases
+- [ ] `NEBARI_BOT_TOKEN` secret configured (for helm-repository sync)
+- [ ] Clean working directory on `main` branch
+- [ ] All desired changes merged to `main`
+
+## Release Steps
+
+### 1. Determine Release Version
+
+Follow [Semantic Versioning](https://semver.org/):
+- **Patch** (`v0.1.1`): Bug fixes, small improvements
+- **Minor** (`v0.2.0`): New features, non-breaking changes
+- **Major** (`v1.0.0`): Breaking changes
+
+### 2. Create and Push Release Tag
+
+```bash
+# Ensure you're on main and up-to-date
+git checkout main
+git pull origin main
+
+# Create release tag (replace with your version)
+git tag v0.2.0
+
+# Checkout the tag
+git checkout v0.2.0
+```
+
+### 3. Prepare Release Artifacts
+
+Run the automated release preparation:
+
+```bash
+make prepare-release
+```
+
+This will:
+- ✅ Verify you're on a release tag
+- ✅ Update `Chart.yaml` version and appVersion
+- ✅ Package the Helm chart
+- ✅ Stage `Chart.yaml` for commit
+
+> **Note**: `values.yaml` image tags are intentionally kept as `"latest"` in source
+> control. CI pins them to the release tag transiently during chart packaging — they
+> are never committed back.
+
+### 4. Review and Commit Changes
+
+```bash
+# Review what was changed
+git status
+git diff --cached
+
+# Commit the release artifacts
+git commit -m "chore: prepare chart for v0.2.0"
+```
+
+### 5. Push Tag
+
+```bash
+# Push the tag to trigger CI
+git push origin v0.2.0
+```
+
+⚠️ **Important**: Do NOT push the commit from step 4 back to main. The chart version changes are tag-specific for the release.
+
+### 6. Create GitHub Release
+
+Visit https://github.com/nebari-dev/nebari-landing/releases/new
+
+- **Tag**: Select `v0.2.0` (the tag you just pushed)
+- **Title**: `v0.2.0` or `nebari-landing v0.2.0`
+- **Description**: Summarize changes (see previous releases for format)
+- Click **Publish release**
+
+### 7. Monitor Release Workflow
+
+The GitHub Actions workflow will automatically:
+
+1. **Validate** backend and frontend code
+2. **Build** multi-arch Docker images:
+   - `quay.io/nebari/nebari-webapi:v0.2.0`
+   - `quay.io/nebari/nebari-landing:v0.2.0`
+3. **Publish** images to Quay.io with semver tags
+4. **Package** and attach Helm chart to the release
+5. **Sync** chart to helm-repository (opens PR automatically)
+
+Watch the workflow at:
+https://github.com/nebari-dev/nebari-landing/actions/workflows/release.yml
+
+Expected duration: ~15-20 minutes
+
+### 8. Verify Release Artifacts
+
+Check that the following were created:
+
+**Docker Images**:
+```bash
+docker pull quay.io/nebari/nebari-webapi:v0.2.0
+docker pull quay.io/nebari/nebari-landing:v0.2.0
+```
+
+**Helm Chart**:
+- Visit your release page: `https://github.com/nebari-dev/nebari-landing/releases/tag/v0.2.0`
+- Verify `nebari-landing-0.2.0.tgz` is attached
+
+**helm-repository PR**:
+- Visit https://github.com/nebari-dev/helm-repository/pulls
+- Find PR titled "feat: add nebari-landing v0.2.0"
+- Review and merge the PR
+
+### 9. Test the Release
+
+**Via Helm repository** (after helm-repository PR is merged):
+```bash
+helm repo add nebari-dev https://nebari-dev.github.io/helm-repository
+helm repo update
+helm search repo nebari-landing --versions
+helm install nebari-landing nebari-dev/nebari-landing --version 0.2.0
+```
+
+**Via direct chart download**:
+```bash
+helm install nebari-landing \
+  https://github.com/nebari-dev/nebari-landing/releases/download/v0.2.0/nebari-landing-0.2.0.tgz
+```
+
+### 10. Update Documentation (if needed)
+
+If this release includes breaking changes or new features:
+- [ ] Update README.md
+- [ ] Update docs/api.md
+- [ ] Update examples in dev/
+
+## Rollback Procedure
+
+If you need to roll back a release:
+
+1. **Delete the GitHub release** (this does NOT delete the tag)
+2. **Delete the container images** from Quay.io (if necessary)
+3. **Close the helm-repository PR** without merging
+4. **Delete the Git tag**:
+   ```bash
+   git tag -d v0.2.0
+   git push origin :refs/tags/v0.2.0
+   ```
+
+## Troubleshooting
+
+### Release workflow fails
+
+**Check the workflow logs first**: https://github.com/nebari-dev/nebari-landing/actions
+
+Common issues:
+
+**Build failure**: Review test output, ensure all tests pass locally with `make test`
+
+**Image push failure**: Verify `QUAY_USERNAME` and `QUAY_PASSWORD` secrets are configured
+
+**Chart packaging failure**: Run `helm lint charts/nebari-landing/` locally
+
+**helm-repository sync failure**: Verify `NEBARI_BOT_ TOKEN` secret has correct permissions
+
+### helm-repository PR not created
+
+Check that:
+1. `NEBARI_BOT_TOKEN` secret exists and has repo access
+2. The release workflow completed successfully
+3. The chart was attached to the GitHub release
+
+You can manually create the PR by following the helm-repository contribution guide.
+
+### Images not multi-arch
+
+Ensure both CI jobs complete:
+- `docker-webapi (amd64)`
+- `docker-webapi (arm64)`
+- `docker-frontend (amd64)`
+- `docker-frontend (arm64)`
+
+Then check the manifest jobs ran successfully.
+
+## Post-Release
+
+After a successful release:
+
+1. **Merge back to main** (if you made documentation changes on the release branch)
+2. **Announce the release** in relevant channels
+3. **Update nebari-infrastructure-core** if this release contains changes that affect the Nebari Operator
+
+## Release Checklist Summary
+
+- [ ] Created and pushed release tag
+- [ ] Ran `make prepare-release`
+- [ ] Committed chart version changes
+- [ ] Published GitHub release
+- [ ] Verified images built successfully
+- [ ] Verified Helm chart attached to release
+- [ ] Merged helm-repository PR
+- [ ] Tested chart installation
+- [ ] Updated documentation (if needed)


### PR DESCRIPTION
## Summary

Improves the release process with automation, documentation, and workflow fixes.

## Changes

### New files
- **`CONTRIBUTING.md`** — Full developer workflow guide covering setup, local dev, making changes, PR process, code style, and debugging
- **`docs/maintainers/release-checklist.md`** — Step-by-step release checklist for maintainers, including rollback procedures and troubleshooting

### `.github/workflows/release.yml`
- Add `sync-helm-repository` job: after `publish-chart` completes, checks out `nebari-dev/helm-repository`, downloads the packaged chart, updates the Helm repo index, and opens an automated PR
- Fix: add missing `azure/setup-helm@v4` step in `sync-helm-repository` (required for `helm repo index`)
- Fix: make image tag `sed` idempotent — pattern changed from `tag: "latest"` to `tag: "[^"]*"` so it works regardless of what `values.yaml` currently contains
- Update header comment to list the new job

### `Makefile`
- Add `helm-package` target — packages the chart to `dist/`
- Add `helm-chart-version` target — updates `Chart.yaml` version and appVersion
- Add `prepare-release` target — validates tag, runs version update + packaging, stages `Chart.yaml`
- `values.yaml` image tags are intentionally kept as `"latest"` in source; CI pins them transiently during chart packaging (never committed)

### `README.md`
- Add Documentation section with links to `CONTRIBUTING.md`, release checklist, and API reference

## Design decision: `values.yaml` tag handling

Previously both the Makefile and CI would try to pin image tags in `values.yaml`. This created a fragile situation where a locally-run `prepare-release` would commit a pinned tag, making CI's `sed` a silent no-op.

The fix: `values.yaml` always carries `tag: "latest"` in source control. CI uses a broader regex (`tag: "[^"]*"`) to pin it transiently at packaging time. The Makefile no longer touches `values.yaml`, and the release checklist documents this clearly.