### PR TITLE
fix(watcher): derive visibility/requiredGroups from spec.auth (operator schema change)

### DIFF
--- a/dev/manifests/test-nebariapps.yaml
+++ b/dev/manifests/test-nebariapps.yaml
@@ -18,7 +18,6 @@ spec:
     icon: "https://fontawesome.com/icons/kubernetes?f=brands&s=solid"
     category: "Platform"
     priority: 10
-    visibility: public
     healthCheck:
       enabled: true
       path: "/api/v1/health"  # webapi returns 200 {"status":"healthy"} → healthy
@@ -36,6 +35,8 @@ spec:
   service:
     name: jupyterhub  # doesn't exist in dev → DNS failure → unhealthy
     port: 8000
+  auth:
+    enabled: true
   landingPage:
     enabled: true
     displayName: "JupyterHub"
@@ -43,7 +44,6 @@ spec:
     icon: "https://jupyter.org/assets/homepage/main-logo.svg"
     category: "Data Science"
     priority: 1
-    visibility: private
     healthCheck:
       enabled: true
       path: "/hub/api/health"  # service unreachable → unhealthy
@@ -62,6 +62,8 @@ spec:
   service:
     name: grafana
     port: 3000
+  auth:
+    enabled: true
   landingPage:
     enabled: true
     displayName: "Grafana"
@@ -69,7 +71,6 @@ spec:
     icon: "https://upload.wikimedia.org/wikipedia/commons/a/a1/Grafana_logo.svg"
     category: "Monitoring"
     priority: 20
-    visibility: private
     # No healthCheck block → status stays "unknown"
 ---
 # Private service — requires JWT + admin group membership.
@@ -84,6 +85,10 @@ spec:
   service:
     name: nebari-landing-webapi
     port: 8080
+  auth:
+    enabled: true
+    groups:
+      - admin
   landingPage:
     enabled: true
     displayName: "Admin Panel"
@@ -92,9 +97,6 @@ spec:
     category: "Platform"
     icon: "https://raw.githubusercontent.com/keycloak/keycloak-misc/main/logo/logo-icon.png"
     priority: 999
-    visibility: private
-    requiredGroups:
-      - "admin"
     healthCheck:
       enabled: true
       path: "/api/v1/health"  # webapi returns 200 {"status":"healthy"} → healthy

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -288,9 +288,21 @@ func toApp(u *unstructured.Unstructured) *sdapp.App {
 	description, _, _ := unstructured.NestedString(u.Object, "spec", "landingPage", "description")
 	icon, _, _ := unstructured.NestedString(u.Object, "spec", "landingPage", "icon")
 	category, _, _ := unstructured.NestedString(u.Object, "spec", "landingPage", "category")
-	visibility, _, _ := unstructured.NestedString(u.Object, "spec", "landingPage", "visibility")
 	externalURL, _, _ := unstructured.NestedString(u.Object, "spec", "landingPage", "externalUrl")
-	requiredGroups, _, _ := unstructured.NestedStringSlice(u.Object, "spec", "landingPage", "requiredGroups")
+	// spec.landingPage no longer carries visibility or requiredGroups (removed from
+	// LandingPageConfig in the operator). The operator's controller derives them from
+	// spec.auth and writes the result to status.serviceDiscovery. Mirror the same
+	// logic here as the spec-level fallback for when status.serviceDiscovery has not
+	// yet been populated (e.g. on first watch event before the controller has reconciled).
+	//   auth disabled (or absent) → visibility="public",  requiredGroups=[]
+	//   auth enabled, no groups   → visibility="private", requiredGroups=[]
+	//   auth enabled, with groups → visibility="private", requiredGroups=spec.auth.groups
+	visibility := "public"
+	var requiredGroups []string
+	if authEnabled, _, _ := unstructured.NestedBool(u.Object, "spec", "auth", "enabled"); authEnabled {
+		visibility = "private"
+		requiredGroups, _, _ = unstructured.NestedStringSlice(u.Object, "spec", "auth", "groups")
+	}
 
 	priority := 100
 	if p, found, _ := unstructured.NestedInt64(u.Object, "spec", "landingPage", "priority"); found {

--- a/test/e2e/webapi_test.go
+++ b/test/e2e/webapi_test.go
@@ -93,12 +93,18 @@ const VeryLongTimeout = 5 * time.Minute
 
 // newNebariApp creates an unstructured NebariApp with a landing-page config.
 // No api/v1 import is needed — the resource is built from raw field maps.
+//
+// The visibility parameter controls access:
+//   - "public" → no auth block (service is visible without authentication)
+//   - any other value (e.g. "private", "authenticated") → spec.auth.enabled=true
+//     (service requires authentication; visibility computed from spec.auth by the controller)
 func newNebariApp(name, namespace, hostname, visibility string, priority int) *unstructured.Unstructured {
 	u := &unstructured.Unstructured{}
 	u.SetGroupVersionKind(nebariAppGVK)
 	u.SetName(name)
 	u.SetNamespace(namespace)
-	_ = unstructured.SetNestedMap(u.Object, map[string]interface{}{
+
+	spec := map[string]interface{}{
 		"hostname": hostname,
 		"service": map[string]interface{}{
 			"name": "test-service",
@@ -109,10 +115,20 @@ func newNebariApp(name, namespace, hostname, visibility string, priority int) *u
 			"displayName": fmt.Sprintf("Test Service %s", name),
 			"description": fmt.Sprintf("E2E test resource with visibility=%s", visibility),
 			"category":    "Testing",
-			"visibility":  visibility,
 			"priority":    int64(priority),
 		},
-	}, "spec")
+	}
+
+	// spec.landingPage no longer carries visibility; access control is expressed
+	// via spec.auth. The operator's controller derives visibility/requiredGroups
+	// from spec.auth and writes them to status.serviceDiscovery.
+	if visibility != "public" {
+		spec["auth"] = map[string]interface{}{
+			"enabled": true,
+		}
+	}
+
+	_ = unstructured.SetNestedMap(u.Object, spec, "spec")
 	return u
 }
 


### PR DESCRIPTION
## What

The operator removed `visibility` and `requiredGroups` from `LandingPageConfig` (`spec.landingPage`). Access control is now expressed via `spec.auth`; the controller derives both fields in `buildServiceDiscoveryStatus()` and writes them to `status.serviceDiscovery`.

## Why

The webapi watcher was still reading the now-removed `spec.landingPage.visibility` and `spec.landingPage.requiredGroups` fields, so all services would fall back to the `private` default (since `lp.Visibility` would always be empty) and no groups would ever be set from spec.

## Changes

### `internal/watcher/watcher.go`
- Removed reads of `spec.landingPage.visibility` and `spec.landingPage.requiredGroups` (fields no longer exist in the CRD).
- Added spec-level fallback that mirrors the operator's own logic:
  - `spec.auth` absent or `enabled: false` → `visibility="public"`, `requiredGroups=[]`
  - `spec.auth.enabled: true` → `visibility="private"`, `requiredGroups=spec.auth.groups`
- `status.serviceDiscovery` override block is unchanged — it still wins in steady state.

### `dev/manifests/test-nebariapps.yaml`
- Removed `visibility`/`requiredGroups` from `spec.landingPage` blocks.
- Added `spec.auth.enabled: true` (+ `groups: [admin]` for admin-panel) to the services that were previously marked private.

### `test/e2e/webapi_test.go`
- Updated `newNebariApp()` helper to inject `spec.auth.enabled: true` instead of the removed `spec.landingPage.visibility` field.