### PR TITLE
fix: remove webapi NebariApp to resolve Gateway listener conflict

### DIFF
--- a/charts/nebari-landing/templates/nebariapp.yaml
+++ b/charts/nebari-landing/templates/nebariapp.yaml
@@ -43,38 +43,21 @@ spec:
     icon: {{ .Values.nebariApp.landingPage.icon | quote }}
     category: {{ .Values.nebariApp.landingPage.category | quote }}
     priority: {{ .Values.nebariApp.landingPage.priority }}
----
-# ── NebariApp: webapi ─────────────────────────────────────────────────────────
-# Routes /api/* directly to the Go webapi service.  JWT validation is handled
-# in-process by the webapi, so no gateway-level auth enforcement is needed.
-apiVersion: reconcilers.nebari.dev/v1
-kind: NebariApp
-metadata:
-  name: {{ include "nebari-landing.fullname" . }}-api
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "nebari-landing.labels" . | nindent 4 }}
-    app.kubernetes.io/component: webapi
-spec:
-  hostname: {{ $host | quote }}
-
-  service:
-    name: {{ include "nebari-landing.fullname" . }}-webapi
-    port: {{ .Values.webapi.service.port }}
-
-  routing:
-    routes:
-      - pathPrefix: /api/
-        pathType: PathPrefix
-    tls:
-      enabled: {{ .Values.httpRoute.tls }}
-
-  auth:
-    enabled: false
-    enforceAtGateway: false
-
-  # The webapi is not represented as a card on the landing page — the landing
-  # page frontend is the user-facing entry point.
-  landingPage:
-    enabled: false
 {{- end }}
+---
+# NOTE: The webapi does not need a NebariApp resource.
+#
+# The webapi is accessed exclusively via internal Kubernetes DNS
+# (nebari-landing-webapi.nebari-system.svc.cluster.local) from the nginx
+# proxy running in the frontend pod. It does not require external routing,
+# TLS certificates, or OIDC client credentials.
+#
+# Only the frontend NebariApp creates:
+#   - HTTPRoutes for external access (/, /oauth2/)
+#   - OIDC client secret (used by oauth2-proxy sidecar)
+#   - Optional Gateway SecurityPolicy
+#
+# The webapi only needs:
+#   - Deployment (to run pods)
+#   - Service (for cluster-internal DNS)
+#   - ServiceAccount + RBAC (to watch NebariApp CRs)


### PR DESCRIPTION
## Summary

Fixes the Gateway listener conflict that was preventing the nebari-landing NebariApp from becoming Ready.

## Problem

The chart was creating **two NebariApp resources** (frontend and api) for the same hostname with `routing.tls.enabled: true`. This caused both to request per-app HTTPS listeners on the Gateway, violating the Gateway API constraint that port + protocol + hostname combinations must be unique.

**Error:**
```
Gateway.gateway.networking.k8s.io 'nebari-gateway' is invalid:
spec.listeners: Invalid value: 'array': Combination of port,
protocol and hostname must be unique for each listener
```

## Root Cause

The **webapi does not need external routing**. It is accessed exclusively via internal Kubernetes DNS (`nebari-landing-webapi.nebari-system.svc.cluster.local`) from the nginx proxy running in the frontend pod.

## Solution

**Removed the `nebari-landing-api` NebariApp resource** from the chart.

### What the frontend NebariApp creates:
- ✅ HTTPRoutes for external access (`/`, `/oauth2/`)
- ✅ OIDC client secret (`nebari-landing-oidc-client` used by oauth2-proxy sidecar)
- ✅ Optional Gateway SecurityPolicy

### What the webapi retains:
- ✅ Deployment (to run pods)
- ✅ Service (for cluster-internal DNS)
- ✅ ServiceAccount + RBAC (to watch NebariApp CRs)
- ❌ No NebariApp (no external routing, no TLS certificate, no OIDC client secret needed)

## Impact

- Fixes the immediate Gateway listener conflict
- Simplifies the chart (one NebariApp instead of two)
- More accurately reflects the architecture (webapi is internal-only)
- OIDC client secret still created by frontend NebariApp (as expected by oauth2-proxy)

## Testing

After deploying this fix:
```bash
kubectl get nebariapp nebari-landing -n nebari-system
# Should show Ready=True, TLSReady=True

kubectl get gateway nebari-gateway -n envoy-gateway-system -o json | jq '.spec.listeners[] | select(.name | contains("nebari-landing"))'
# Should show only one listener (or use shared wildcard listener if tls: false)
```