### PR TITLE
fix(chart): set auth.enabled=true with enforceAtGateway=false for landing page

### DIFF
--- a/charts/nebari-landing/templates/nebariapp.yaml
+++ b/charts/nebari-landing/templates/nebariapp.yaml
@@ -31,9 +31,11 @@ spec:
       enabled: {{ .Values.httpRoute.tls }}
 
   # oauth2-proxy handles authentication at the sidecar level; no SecurityPolicy
-  # is needed at the gateway.
+  # is needed at the gateway.  The operator must still provision the OIDC client
+  # in Keycloak (auth.enabled: true) so that the proxy Secret is written —
+  # oauth2-proxy blocks on that Secret at startup.
   auth:
-    enabled: false
+    enabled: true
     enforceAtGateway: false
 
   landingPage:


### PR DESCRIPTION
## Problem

The Helm chart template had `auth.enabled: false` for the landing page NebariApp.

With `auth.enabled: false` the operator skips OIDC client provisioning entirely — no Keycloak client is created and no proxy Secret is written. The oauth2-proxy sidecar blocks on that Secret at startup, causing the frontend pod to never become ready.

## Fix

Set `auth.enabled: true` + `enforceAtGateway: false`, which is the correct pattern for sidecar-managed auth:

| Field | Value | Effect |
|---|---|---|
| `auth.enabled` | `true` | Operator provisions Keycloak OIDC client and writes proxy Secret |
| `enforceAtGateway` | `false` | No gateway SecurityPolicy — oauth2-proxy sidecar handles the OIDC flow |

This matches the dev manifest at `dev/manifests/nebari-landingpage/base/nebariapp.yaml` which was already correct.