### PR TITLE
fix(chart): fix AES cookie secret size (stringData + 16 bytes)

### DIFF
--- a/charts/nebari-landing/templates/frontend/oauth2-proxy-cookie-secret.yaml
+++ b/charts/nebari-landing/templates/frontend/oauth2-proxy-cookie-secret.yaml
@@ -5,7 +5,7 @@ operator has not pre-created one.
 The Helm `lookup` function reads the existing Secret on upgrades so the cookie
 value is preserved across deployments (preventing all users from being logged
 out on every helm upgrade). On the very first install, `lookup` returns nil and
-Helm generates a fresh 32-byte random value.
+Helm generates a fresh 16-byte random value (base64-encoded → AES-128 key).
 
 If `existingCookieSecret` is set the chart assumes the operator/admin manages
 the secret externally and renders nothing here.
@@ -23,7 +23,10 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
 type: Opaque
-data:
+stringData:
   # Preserved across upgrades via lookup; generated fresh on first install.
-  cookie-secret: {{ if $existing }}{{ index $existing.data "cookie-secret" }}{{ else }}{{ randBytes 32 | b64enc }}{{ end }}
+  # 16 raw bytes base64-encoded → oauth2-proxy decodes to a valid AES-128 key.
+  # stringData avoids double-encoding (ArgoCD ServerSideApply re-encodes data:
+  # values, causing the pod to receive the base64 string instead of raw bytes).
+  cookie-secret: {{ if $existing }}{{ index $existing.data "cookie-secret" | b64dec }}{{ else }}{{ randBytes 16 | b64enc }}{{ end }}
 {{- end }}


### PR DESCRIPTION
## Problem

The oauth2-proxy sidecar was failing with:
```
cookie_secret must be 16, 24, or 32 bytes to create an AES cipher, but is 44 bytes
```

### Root cause

The template used `data:` + `randBytes 32 | b64enc`. When ArgoCD applies with `ServerSideApply=true`, it treats `data:` values as opaque strings and re-encodes them, resulting in **double base64 encoding**. The pod receives the 44-character base64 string instead of raw bytes:

```
kubectl get secret nebari-landing-oauth2-proxy-cookie -o jsonpath='{.data.cookie-secret}' | base64 -d
# → SfNT6m/kABrVxIEpjW1v3jMBnvSUVPGCtZpsssWpsys=   ← still base64, 44 chars
```

## Fix

- `data:` → `stringData:` — Kubernetes handles the single encoding layer, no double-encoding regardless of how the apply is done
- `randBytes 32` → `randBytes 16` — 16 bytes → AES-128, valid and simpler
- Upgrade path: `.data` values are already base64 so `b64dec` before writing to `stringData` to avoid a third encoding layer

## Required cluster action

The broken secret must be deleted once so Helm regenerates it cleanly on the next ArgoCD sync:
```sh
kubectl delete secret -n nebari-system nebari-landing-oauth2-proxy-cookie
```