### PR TITLE
fix(chart): derive frontend Keycloak clientId from NebariApp name

### DIFF
--- a/charts/nebari-landing/templates/NOTES.txt
+++ b/charts/nebari-landing/templates/NOTES.txt
@@ -16,7 +16,7 @@ Traffic routing (Envoy Gateway HTTPRoute):
 {{- end }}
 
 Pre-requisites to verify before using:
-  1. Keycloak OIDC client "{{ printf "%s-%s" .Release.Namespace (include "nebari-landing.fullname" .) }}" exists in realm {{ .Values.webapi.keycloak.realm }}
+  1. Keycloak OIDC client "{{ default (printf "%s-%s" .Release.Namespace (include "nebari-landing.fullname" .)) .Values.frontend.oauth2Proxy.clientId }}" exists in realm {{ .Values.webapi.keycloak.realm }}
      with redirect URI: {{ if .Values.httpRoute.tls }}https{{ else }}http{{ end }}://{{ .Values.httpRoute.hostname }}/oauth2/callback
 
   2. OIDC client-secret: the nebari-operator creates

--- a/charts/nebari-landing/templates/frontend/configmap.yaml
+++ b/charts/nebari-landing/templates/frontend/configmap.yaml
@@ -15,7 +15,7 @@ data:
       "keycloak": {
         "url":      {{ .Values.frontend.keycloak.url      | quote }},
         "realm":    {{ .Values.frontend.keycloak.realm     | quote }},
-        "clientId": {{ printf "%s-%s" .Release.Namespace (include "nebari-landing.fullname" .) | quote }}
+        "clientId": {{ default (printf "%s-%s" .Release.Namespace (include "nebari-landing.fullname" .)) .Values.frontend.keycloak.clientId | quote }}
       }
     }
 

--- a/charts/nebari-landing/templates/frontend/deployment.yaml
+++ b/charts/nebari-landing/templates/frontend/deployment.yaml
@@ -81,8 +81,8 @@ spec:
           args:
             - --provider=oidc
             - --oidc-issuer-url={{ required "frontend.oauth2Proxy.oidcIssuerUrl is required" .Values.frontend.oauth2Proxy.oidcIssuerUrl }}
-            {{- /* Client ID matches the operator naming convention: <namespace>-<nebariapp-name> */}}
-            - --client-id={{ printf "%s-%s" .Release.Namespace (include "nebari-landing.fullname" .) }}
+            {{- /* Client ID: use override if set, otherwise derive from operator convention: <namespace>-<nebariapp-name> */}}
+            - --client-id={{ default (printf "%s-%s" .Release.Namespace (include "nebari-landing.fullname" .)) .Values.frontend.oauth2Proxy.clientId }}
             - --upstream=http://127.0.0.1:{{ .Values.frontend.port }}
             - --http-address=0.0.0.0:{{ .Values.frontend.oauth2Proxy.port }}
             - --email-domain={{ .Values.frontend.oauth2Proxy.emailDomain }}

--- a/charts/nebari-landing/values.yaml
+++ b/charts/nebari-landing/values.yaml
@@ -33,8 +33,10 @@ frontend:
     # e.g. https://keycloak.example.com/auth
     url: ""
     realm: "nebari"
-    # clientId is derived automatically following the operator convention:
-    # <namespace>-<nebariapp-name>  — do not set this manually.
+    # OIDC client ID sent by the Keycloak JS adapter in the browser.
+    # Leave empty to use the operator convention: <namespace>-<nebariapp-name>.
+    # Override only when the Keycloak client was provisioned with a different ID.
+    clientId: ""
 
   resources:
     requests:
@@ -63,8 +65,10 @@ frontend:
     # frontend NebariApp: it follows the pattern <nebariapp-name>-oidc-client.
     # Leave empty to use the operator-created default derived from the chart
     # fullname: "<fullname>-oidc-client".
-    # NOTE: The OIDC client ID is derived automatically from the NebariApp name
-    # following the operator convention: <namespace>-<nebariapp-name>.
+    # OIDC client ID passed to oauth2-proxy via --client-id.
+    # Leave empty to use the operator convention: <namespace>-<nebariapp-name>.
+    # Override only when the Keycloak client was provisioned with a different ID.
+    clientId: ""
     existingClientSecret: ""
 
     # Key inside existingClientSecret that holds the OIDC client secret value.


### PR DESCRIPTION
## Problem

The Keycloak JS adapter `clientId` rendered into `config.json` was hardcoded as `nebari-frontend-spa` in `values.yaml`. This value is fetched by the browser at startup to initialise the Keycloak JS adapter.

However, the nebari-operator provisions the OIDC client in Keycloak using the convention:
```
<namespace>-<nebariapp-name>
```

So if the release name or `nameOverride` differed from `nebari-landing`, the browser-side client ID would not match the registered Keycloak client, breaking the login flow.

## Fix

- **configmap.yaml**: derive `clientId` using the same Helm expression as the oauth2-proxy `--client-id` arg:
  ```
  {{ printf "%s-%s" .Release.Namespace (include "nebari-landing.fullname" .) }}
  ```
- **values.yaml**: remove the now-unused `frontend.keycloak.clientId` field; add a comment explaining the convention