### PR TITLE
fix(frontend): preserve per-user pin state on WebSocket service updates

### DIFF
--- a/frontend/src/api/mapServices.ts
+++ b/frontend/src/api/mapServices.ts
@@ -13,7 +13,7 @@ export function mapService(service: BackendService): Service {
           : "Unknown",
     description: service.description,
     category: service.category ? [service.category] : [],
-    pinned: service.pinned,
+    pinned: false,
     image: service.icon,
     url: service.url,
   };

--- a/frontend/src/api/serviceSocket.ts
+++ b/frontend/src/api/serviceSocket.ts
@@ -11,7 +11,6 @@ export type BackendService = {
   icon: string;
   category: string;
   priority: number;
-  pinned: boolean;
   visibility: string;
   health: {
     status: string;

--- a/frontend/src/app/index.tsx
+++ b/frontend/src/app/index.tsx
@@ -23,7 +23,6 @@ type BackendSocketService = {
   icon: string;
   category: string;
   priority: number;
-  pinned: boolean;
   visibility: string;
   health: {
     status: string;
@@ -43,13 +42,13 @@ type BackendSocketNotification = {
 
 type AppSocketMessage =
   | {
-      type: "added" | "modified" | "deleted";
-      service: BackendSocketService;
-    }
+    type: "added" | "modified" | "deleted";
+    service: BackendSocketService;
+  }
   | {
-      type: "notification.created";
-      notification: BackendSocketNotification;
-    };
+    type: "notification.created";
+    notification: BackendSocketNotification;
+  };
 
 export default function App() {
   const [isDarkMode, setIsDarkMode] = useState(false);
@@ -150,7 +149,9 @@ export default function App() {
 
               if (exists) {
                 return current.map((service) =>
-                  service.id === nextService.id ? nextService : service
+                  service.id === nextService.id
+                    ? { ...nextService, pinned: service.pinned }
+                    : service
                 );
               }
 
@@ -159,7 +160,9 @@ export default function App() {
 
             case "modified":
               return current.map((service) =>
-                service.id === nextService.id ? nextService : service
+                service.id === nextService.id
+                  ? { ...nextService, pinned: service.pinned }
+                  : service
               );
 
             case "deleted":


### PR DESCRIPTION
## Problem

Every 30-second health-probe WebSocket event (`modified`) was overwriting the pin state of all service cards to `false`.

**Root cause:** `BackendService` and `BackendSocketService` TypeScript types both declared `pinned: boolean`, but `ServiceInfo` — the Go struct serialised into WebSocket frames — has no `pinned` field. Pin state is per-user, stored in Redis, and only materialised by `GET /api/v1/services` via `toServiceView()`. So `mapService()` was reading `undefined` and coercing it to `false` on every WS event.

## Changes

| File | Change |
|------|--------|
| `serviceSocket.ts` | Remove `pinned: boolean` from `BackendService` — field is not present in WS payloads |
| `index.tsx` | Remove `pinned: boolean` from `BackendSocketService` (same reason) |
| `mapServices.ts` | `pinned: false` — `mapService()` is only called for WS events; REST responses go through a separate path |
| `index.tsx` WS handlers | `modified` and `added`-dedup now merge as `{ ...nextService, pinned: service.pinned }` to preserve pin state from React state |

## Why not include pinned in WS events?

The hub uses Redis Pub/Sub fan-out — one message is broadcast to every connected client. Pin state is per-user so there is no single `pinned` value that is correct for all recipients. The REST layer is the right place for it.