### PR TITLE
feat(watcher): support cross-namespace services and health-check port override

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -31,6 +31,12 @@ type App struct {
 	// health checks.
 	ServiceName string
 
+	// ServiceNamespace is spec.service.namespace — the namespace containing the
+	// Kubernetes Service. Defaults to Namespace (the NebariApp's own namespace)
+	// when not explicitly set, but must be specified when the target Service
+	// lives in a different namespace (e.g. Keycloak in the keycloak namespace).
+	ServiceNamespace string
+
 	// ServicePort is spec.service.port — the port on the Kubernetes Service.
 	ServicePort int
 
@@ -97,4 +103,10 @@ type HealthCheck struct {
 	// TimeoutSeconds is the per-probe HTTP timeout.
 	// Defaults to 5 when not set.
 	TimeoutSeconds int
+
+	// Port overrides the service port for the health probe. Useful when the
+	// target exposes health endpoints on a separate management port (e.g.
+	// Keycloak X exposes /health/ready on port 9000, not the main 8080).
+	// When 0, spec.service.port is used.
+	Port int
 }

--- a/internal/cache/service_cache.go
+++ b/internal/cache/service_cache.go
@@ -227,8 +227,21 @@ func buildHealthCheckConfig(a *sdapp.App) *HealthCheckConfig {
 	if servicePort == 0 {
 		servicePort = 80
 	}
+	// Allow healthCheck.port to override the service port for services that
+	// expose health endpoints on a separate management port (e.g. Keycloak X
+	// management port 9000 vs main HTTP port 8080).
+	if hc.Port > 0 {
+		servicePort = hc.Port
+	}
+	// Use ServiceNamespace (spec.service.namespace) so cross-namespace services
+	// (e.g. Keycloak in 'keycloak', ArgoCD in 'argocd') are probed via the
+	// correct in-cluster DNS name rather than the NebariApp's own namespace.
+	serviceNamespace := a.ServiceNamespace
+	if serviceNamespace == "" {
+		serviceNamespace = a.Namespace
+	}
 	return &HealthCheckConfig{
-		ProbeURL:        fmt.Sprintf("http://%s.%s:%d%s", serviceName, a.Namespace, servicePort, path),
+		ProbeURL:        fmt.Sprintf("http://%s.%s:%d%s", serviceName, serviceNamespace, servicePort, path),
 		IntervalSeconds: interval,
 		TimeoutSeconds:  timeout,
 	}

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -336,15 +336,20 @@ func lpEnabled(u *unstructured.Unstructured) bool {
 func toApp(u *unstructured.Unstructured) *sdapp.App {
 	hostname, _, _ := unstructured.NestedString(u.Object, "spec", "hostname")
 	serviceName, _, _ := unstructured.NestedString(u.Object, "spec", "service", "name")
+	serviceNamespace, _, _ := unstructured.NestedString(u.Object, "spec", "service", "namespace")
 	servicePort, _, _ := unstructured.NestedInt64(u.Object, "spec", "service", "port")
+	if serviceNamespace == "" {
+		serviceNamespace = u.GetNamespace()
+	}
 	a := &sdapp.App{
-		UID:         string(u.GetUID()),
-		Name:        u.GetName(),
-		Namespace:   u.GetNamespace(),
-		Hostname:    hostname,
-		TLSEnabled:  tlsEnabled(u),
-		ServiceName: serviceName,
-		ServicePort: int(servicePort),
+		UID:              string(u.GetUID()),
+		Name:             u.GetName(),
+		Namespace:        u.GetNamespace(),
+		Hostname:         hostname,
+		TLSEnabled:       tlsEnabled(u),
+		ServiceName:      serviceName,
+		ServiceNamespace: serviceNamespace,
+		ServicePort:      int(servicePort),
 	}
 
 	if !lpEnabled(u) {
@@ -381,6 +386,7 @@ func toApp(u *unstructured.Unstructured) *sdapp.App {
 	hcPath, _, _ := unstructured.NestedString(u.Object, "spec", "landingPage", "healthCheck", "path")
 	hcInterval, _, _ := unstructured.NestedInt64(u.Object, "spec", "landingPage", "healthCheck", "intervalSeconds")
 	hcTimeout, _, _ := unstructured.NestedInt64(u.Object, "spec", "landingPage", "healthCheck", "timeoutSeconds")
+	hcPort, _, _ := unstructured.NestedInt64(u.Object, "spec", "landingPage", "healthCheck", "port")
 	var healthCheck *sdapp.HealthCheck
 	if hcEnabled {
 		healthCheck = &sdapp.HealthCheck{
@@ -388,6 +394,7 @@ func toApp(u *unstructured.Unstructured) *sdapp.App {
 			Path:            hcPath,
 			IntervalSeconds: int(hcInterval),
 			TimeoutSeconds:  int(hcTimeout),
+			Port:            int(hcPort),
 		}
 	}
 


### PR DESCRIPTION
## Problem

Two gaps in how NebariApp health probes are built:

### 1. Cross-namespace services probed with wrong DNS name

`buildHealthCheckConfig` always used `a.Namespace` (the NebariApp's own namespace) to form the in-cluster probe URL:
```
http://{service-name}.{nebariapp-namespace}:{port}{path}
```
Services that live in a different namespace — Keycloak in `keycloak`, ArgoCD in `argocd`, JupyterHub in `jhub` — were probed via the wrong DNS name and returned connection errors on every health check.

### 2. No way to override the health-probe port

Some services expose their health endpoint on a separate management port (Keycloak X: `/health/ready` on port `9000`, main HTTP on `8080`). `spec.service.port` controls the port used in service URLs shown to users; it shouldn't have to be set to the management port just to make health checks work.

## Changes

| File | Change |
|------|--------|
| `internal/app/app.go` | Add `ServiceNamespace` to `App` and `Port` to `HealthCheck` |
| `internal/watcher/watcher.go` | Read `spec.service.namespace` and `spec.landingPage.healthCheck.port` from the CR; default namespace to CR's own namespace |
| `internal/cache/service_cache.go` | Use `serviceNamespace` in the probe URL; use `hc.Port` when > 0 to override `spec.service.port` for the probe |

## Example NebariApp CR

```yaml
spec:
  service:
    name: keycloakx-http
    namespace: keycloak   # cross-namespace
    port: 8080            # port used in service URLs
  landingPage:
    healthCheck:
      enabled: true
      path: /health/ready
      port: 9000          # management port — separate from spec.service.port
```