### PR TITLE
chore: auto-download kubectl and helm in dev/Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ frontend/dist/
 
 # OS
 .DS_Store
+
+# Local dev binaries (auto-downloaded by dev/Makefile)
+.bin/

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -24,7 +24,7 @@
 #   make info           – print useful URLs / credentials
 #
 # Prerequisites:
-#   docker, kubectl, helm  (the Makefile downloads minikube automatically)
+#   docker  (kubectl, helm, and minikube are downloaded automatically to .bin/)
 ##############################################################################
 
 # ── Configurable variables ──────────────────────────────────────────────────
@@ -98,6 +98,14 @@ BIN_DIR       := $(CURDIR)/.bin
 MINIKUBE      := $(BIN_DIR)/minikube
 MINIKUBE_URL  := https://storage.googleapis.com/minikube/releases/latest/minikube-$(OS)-$(ARCH)
 
+KUBECTL_VERSION ?= v1.32.0
+KUBECTL        := $(BIN_DIR)/kubectl
+KUBECTL_URL    := https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/$(OS)/$(ARCH)/kubectl
+
+HELM_VERSION   ?= v3.17.1
+HELM           := $(BIN_DIR)/helm
+HELM_URL       := https://get.helm.sh/helm-$(HELM_VERSION)-$(OS)-$(ARCH).tar.gz
+
 # ── Phony targets ────────────────────────────────────────────────────────────
 
 .PHONY: setup cluster-start cluster-delete \
@@ -110,12 +118,12 @@ MINIKUBE_URL  := https://storage.googleapis.com/minikube/releases/latest/minikub
         argocd-apps install uninstall dev-watch stop-dev-watch dev-watch-status info \
         port-forward stop-port-forward \
         minikube-tunnel stop-minikube-tunnel \
-        deps-check _minikube
+        deps-check _minikube _kubectl _helm
 
 # ── Main entry point ─────────────────────────────────────────────────────────
 
 ## setup: full end-to-end setup (cluster + image + keycloak + app)
-setup: _minikube cluster-start image-build cert-manager metallb keycloak keycloak-client frontend-client operator-install install test-apps port-forward info
+setup: _minikube _kubectl _helm cluster-start image-build cert-manager metallb keycloak keycloak-client frontend-client operator-install install test-apps port-forward info
 	@echo ""
 	@echo "✅  Setup complete. Run 'make info' at any time for URLs."
 
@@ -138,18 +146,53 @@ _minikube:
 	  fi; \
 	fi
 
-## deps-check: verify required tools are installed
+## _kubectl: download kubectl binary if not already present
+_kubectl:
+	@if command -v kubectl > /dev/null 2>&1; then \
+	  echo "✔  kubectl found at $$(command -v kubectl) (version: $$(kubectl version --client --short 2>/dev/null || kubectl version --client 2>/dev/null | head -1))"; \
+	else \
+	  mkdir -p $(BIN_DIR); \
+	  if [ ! -x $(KUBECTL) ]; then \
+	    echo "→  Downloading kubectl $(KUBECTL_VERSION) for $(OS)/$(ARCH) …"; \
+	    curl -fsSL $(KUBECTL_URL) -o $(KUBECTL); \
+	    chmod +x $(KUBECTL); \
+	    echo "✔  kubectl saved to $(KUBECTL)"; \
+	  else \
+	    echo "✔  kubectl already downloaded at $(KUBECTL)"; \
+	  fi; \
+	fi
+
+## _helm: download helm binary if not already present
+_helm:
+	@if command -v helm > /dev/null 2>&1; then \
+	  echo "✔  helm found at $$(command -v helm) (version: $$(helm version --short 2>/dev/null))"; \
+	else \
+	  mkdir -p $(BIN_DIR); \
+	  if [ ! -x $(HELM) ]; then \
+	    echo "→  Downloading helm $(HELM_VERSION) for $(OS)/$(ARCH) …"; \
+	    curl -fsSL $(HELM_URL) -o /tmp/helm-nebari-landing.tar.gz; \
+	    tar xzf /tmp/helm-nebari-landing.tar.gz -C $(BIN_DIR) --strip-components=1 $(OS)-$(ARCH)/helm; \
+	    rm -f /tmp/helm-nebari-landing.tar.gz; \
+	    echo "✔  helm saved to $(HELM)"; \
+	  else \
+	    echo "✔  helm already downloaded at $(HELM)"; \
+	  fi; \
+	fi
+
+## deps-check: verify docker is installed (kubectl, helm, minikube are auto-downloaded)
 deps-check:
 	@echo "Checking required tools …"
-	@command -v docker  > /dev/null || (echo "✗  docker not found"  && exit 1)
-	@command -v kubectl > /dev/null || (echo "✗  kubectl not found" && exit 1)
-	@command -v helm    > /dev/null || (echo "✗  helm not found"    && exit 1)
-	@echo "✔  docker, kubectl, helm found"
+	@command -v docker > /dev/null || (echo "✗  docker not found — please install Docker" && exit 1)
+	@echo "✔  docker found"
+	@echo "   kubectl, helm, and minikube are downloaded automatically to $(BIN_DIR)/"
+	@echo "   Run 'make -f dev/Makefile setup' to bootstrap everything."
 
 # ── Cluster lifecycle ─────────────────────────────────────────────────────────
 
-# Resolve the minikube binary (system or local .bin/)
+# Resolve tool binaries — prefer system-installed, fall back to local .bin/
 MINIKUBE_BIN := $(shell command -v minikube 2>/dev/null || echo $(MINIKUBE))
+KUBECTL_BIN  := $(shell command -v kubectl  2>/dev/null || echo $(KUBECTL))
+HELM_BIN     := $(shell command -v helm     2>/dev/null || echo $(HELM))
 
 ## cluster-start: create (or start) the minikube cluster
 cluster-start:
@@ -175,12 +218,12 @@ cluster-delete:
 # $(2) = pod label selector (e.g. app.kubernetes.io/component=webapi)
 # $(3) = image ref (e.g. $(WEBAPI_IMAGE))
 define _minikube-reload
-	@REPLICAS=$$(kubectl get deploy $(HELM_RELEASE)-$(1) -n $(NAMESPACE_APP) \
+	@REPLICAS=$$($(KUBECTL_BIN) get deploy $(HELM_RELEASE)-$(1) -n $(NAMESPACE_APP) \
 	  -o jsonpath='{.spec.replicas}' 2>/dev/null || echo 0); \
 	if [ "$$REPLICAS" -gt 0 ] 2>/dev/null; then \
 	  echo "→  Scaling $(HELM_RELEASE)-$(1) to 0 to release the stale image …"; \
-	  kubectl scale deployment $(HELM_RELEASE)-$(1) -n $(NAMESPACE_APP) --replicas=0; \
-	  kubectl wait --for=delete pod -l $(2) -n $(NAMESPACE_APP) --timeout=60s 2>/dev/null || true; \
+	  $(KUBECTL_BIN) scale deployment $(HELM_RELEASE)-$(1) -n $(NAMESPACE_APP) --replicas=0; \
+	  $(KUBECTL_BIN) wait --for=delete pod -l $(2) -n $(NAMESPACE_APP) --timeout=60s 2>/dev/null || true; \
 	fi; \
 	echo "→  Removing old $(3) from minikube (if present) …"; \
 	$(MINIKUBE_BIN) -p $(CLUSTER_NAME) image rm $(3) 2>/dev/null || true; \
@@ -188,7 +231,7 @@ define _minikube-reload
 	$(MINIKUBE_BIN) -p $(CLUSTER_NAME) image load $(3); \
 	if [ "$$REPLICAS" -gt 0 ] 2>/dev/null; then \
 	  echo "→  Restoring $(HELM_RELEASE)-$(1) to $$REPLICAS replica(s) …"; \
-	  kubectl scale deployment $(HELM_RELEASE)-$(1) -n $(NAMESPACE_APP) --replicas=$$REPLICAS; \
+	  $(KUBECTL_BIN) scale deployment $(HELM_RELEASE)-$(1) -n $(NAMESPACE_APP) --replicas=$$REPLICAS; \
 	fi
 endef
 
@@ -209,13 +252,13 @@ CERT_MANAGER_VERSION ?= v1.16.3
 ## cert-manager: install cert-manager and a selfsigned ClusterIssuer
 cert-manager:
 	@echo "→  Installing cert-manager $(CERT_MANAGER_VERSION) …"
-	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml
-	kubectl rollout status deployment/cert-manager              -n cert-manager --timeout=3m
-	kubectl rollout status deployment/cert-manager-webhook       -n cert-manager --timeout=3m
-	kubectl rollout status deployment/cert-manager-cainjector   -n cert-manager --timeout=3m
+	$(KUBECTL_BIN) apply -f https://github.com/cert-manager/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml
+	$(KUBECTL_BIN) rollout status deployment/cert-manager              -n cert-manager --timeout=3m
+	$(KUBECTL_BIN) rollout status deployment/cert-manager-webhook       -n cert-manager --timeout=3m
+	$(KUBECTL_BIN) rollout status deployment/cert-manager-cainjector   -n cert-manager --timeout=3m
 	@echo "→  Waiting for cert-manager webhook TLS to be ready …"
 	@for i in 1 2 3 4 5 6 7 8 9 10; do \
-	  kubectl apply -f dev/manifests/cert-manager/selfsigned-clusterissuer.yaml 2>&1 && break; \
+	  $(KUBECTL_BIN) apply -f dev/manifests/cert-manager/selfsigned-clusterissuer.yaml 2>&1 && break; \
 	  echo "  webhook not ready yet (attempt $$i/10), retrying in 5 s …"; \
 	  sleep 5; \
 	done
@@ -231,7 +274,7 @@ metallb:
 	@echo "→  Enabling MetalLB addon …"
 	$(MINIKUBE_BIN) addons enable metallb -p $(CLUSTER_NAME)
 	@echo "→  Waiting for MetalLB controller to become ready …"
-	kubectl rollout status deployment/controller -n metallb-system --timeout=3m
+	$(KUBECTL_BIN) rollout status deployment/controller -n metallb-system --timeout=3m
 	@MINIKUBE_IP=$$($(MINIKUBE_BIN) ip -p $(CLUSTER_NAME)); \
 	 SUBNET=$$(echo "$$MINIKUBE_IP" | sed 's/\.[0-9]*$$//'); \
 	 POOL_START=$${SUBNET}.100; \
@@ -239,7 +282,7 @@ metallb:
 	 echo "→  Detected minikube subnet: $${SUBNET}.0/24"; \
 	 echo "→  Configuring IP pool $${POOL_START}-$${POOL_END} …"; \
 	 printf 'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  namespace: metallb-system\n  name: config\ndata:\n  config: |\n    address-pools:\n    - name: nebari-local\n      protocol: layer2\n      addresses:\n      - %s-%s\n' \
-	   "$${POOL_START}" "$${POOL_END}" | kubectl apply -f -; \
+	   "$${POOL_START}" "$${POOL_END}" | $(KUBECTL_BIN) apply -f -; \
 	 echo "✔  MetalLB ready. Pinned IPs:"; \
 	 echo "     Keycloak : $${SUBNET}.100 (override: LB_IP_KEYCLOAK)"; \
 	 echo "     WebAPI   : $${SUBNET}.101 (override: LB_IP_WEBAPI)"; \
@@ -257,25 +300,25 @@ keycloak: postgresql keycloak-install keycloak-realm
 
 ## postgresql-secrets: create the k8s secrets required by PostgreSQL and Keycloak
 postgresql-secrets:
-	kubectl create namespace $(NAMESPACE_KC) --dry-run=client -o yaml | kubectl apply -f -
-	kubectl create secret generic keycloak-admin-credentials \
+	$(KUBECTL_BIN) create namespace $(NAMESPACE_KC) --dry-run=client -o yaml | $(KUBECTL_BIN) apply -f -
+	$(KUBECTL_BIN) create secret generic keycloak-admin-credentials \
 	  --from-literal=admin-password=$(KEYCLOAK_ADMIN_PASSWORD) \
 	  --namespace $(NAMESPACE_KC) \
-	  --dry-run=client -o yaml | kubectl apply -f -
-	kubectl create secret generic keycloak-postgresql-credentials \
+	  --dry-run=client -o yaml | $(KUBECTL_BIN) apply -f -
+	$(KUBECTL_BIN) create secret generic keycloak-postgresql-credentials \
 	  --from-literal=password=$(KEYCLOAK_DB_PASSWORD) \
 	  --namespace $(NAMESPACE_KC) \
-	  --dry-run=client -o yaml | kubectl apply -f -
-	kubectl create secret generic nebari-realm-admin-credentials \
+	  --dry-run=client -o yaml | $(KUBECTL_BIN) apply -f -
+	$(KUBECTL_BIN) create secret generic nebari-realm-admin-credentials \
 	  --from-literal=username=admin \
 	  --from-literal=password=$(REALM_ADMIN_PASSWORD) \
 	  --namespace $(NAMESPACE_KC) \
-	  --dry-run=client -o yaml | kubectl apply -f -
+	  --dry-run=client -o yaml | $(KUBECTL_BIN) apply -f -
 
 ## postgresql: install PostgreSQL (external DB for Keycloak)
 postgresql: postgresql-secrets
 	@echo "→  Installing PostgreSQL …"
-	helm upgrade --install postgresql $(POSTGRESQL_CHART) \
+	$(HELM_BIN) upgrade --install postgresql $(POSTGRESQL_CHART) \
 	  --version $(POSTGRESQL_VERSION) \
 	  --namespace $(NAMESPACE_KC) \
 	  --values dev/keycloak/postgresql-values.yaml \
@@ -284,14 +327,14 @@ postgresql: postgresql-secrets
 
 keycloak-install:
 	@echo "→  Installing Keycloak (codecentric/keycloakx) …"
-	kubectl create namespace $(NAMESPACE_KC) --dry-run=client -o yaml | kubectl apply -f -
-	helm repo add codecentric $(KEYCLOAK_CHART) --force-update
+	$(KUBECTL_BIN) create namespace $(NAMESPACE_KC) --dry-run=client -o yaml | $(KUBECTL_BIN) apply -f -
+	$(HELM_BIN) repo add codecentric $(KEYCLOAK_CHART) --force-update
 	@MINIKUBE_IP=$$($(MINIKUBE_BIN) ip -p $(CLUSTER_NAME)); \
 	 SUBNET=$$(echo "$$MINIKUBE_IP" | sed 's/\.[0-9]*$$//'); \
 	 export KC_HOSTNAME_URL="http://localhost:8180/auth"; \
 	 echo "→  Keycloak public URL (KC_HOSTNAME_URL): $$KC_HOSTNAME_URL"; \
 	 envsubst < dev/keycloak/values.yaml | \
-	 helm upgrade --install $(HELM_RELEASE_KC) codecentric/$(KEYCLOAK_CHART_NAME) \
+	 $(HELM_BIN) upgrade --install $(HELM_RELEASE_KC) codecentric/$(KEYCLOAK_CHART_NAME) \
 	   --version $(KEYCLOAK_VERSION) \
 	   --namespace $(NAMESPACE_KC) \
 	   --values - \
@@ -301,18 +344,18 @@ keycloak-install:
 ## keycloak-realm: run the kcadm Job to create and populate the nebari realm
 keycloak-realm:
 	@echo "→  Running realm setup Job …"
-	kubectl delete job keycloak-realm-setup -n $(NAMESPACE_KC) --ignore-not-found
-	kubectl apply -f dev/keycloak/realm-setup-job.yaml
-	kubectl wait --for=condition=complete job/keycloak-realm-setup \
+	$(KUBECTL_BIN) delete job keycloak-realm-setup -n $(NAMESPACE_KC) --ignore-not-found
+	$(KUBECTL_BIN) apply -f dev/keycloak/realm-setup-job.yaml
+	$(KUBECTL_BIN) wait --for=condition=complete job/keycloak-realm-setup \
 	  -n $(NAMESPACE_KC) --timeout=5m
 	@echo "✔  Realm 'nebari' configured"
 
 ## keycloak-client: create the webapi public OIDC client in the nebari realm
 keycloak-client:
 	@echo "→  Creating webapi Keycloak client …"
-	kubectl delete job keycloak-webapi-client-setup -n $(NAMESPACE_KC) --ignore-not-found
-	kubectl apply -f dev/keycloak/webapi-client-job.yaml
-	kubectl wait --for=condition=complete job/keycloak-webapi-client-setup \
+	$(KUBECTL_BIN) delete job keycloak-webapi-client-setup -n $(NAMESPACE_KC) --ignore-not-found
+	$(KUBECTL_BIN) apply -f dev/keycloak/webapi-client-job.yaml
+	$(KUBECTL_BIN) wait --for=condition=complete job/keycloak-webapi-client-setup \
 	  -n $(NAMESPACE_KC) --timeout=3m
 	@echo "✔  Keycloak webapi client ready"
 
@@ -326,17 +369,17 @@ keycloak-client:
 ##      consumed by the Helm chart's oauth2-proxy sidecar
 frontend-client:
 	@echo "→  Creating nebari-landingpage Keycloak client (dev fallback) …"
-	kubectl delete job keycloak-frontend-client-setup -n $(NAMESPACE_KC) --ignore-not-found
-	PORT_LANDING=$(PORT_LANDING) LANDING_HOST=$(LANDING_HOST) envsubst '$${PORT_LANDING} $${LANDING_HOST}' < dev/keycloak/frontend-client-job.yaml | kubectl apply -f -
-	kubectl wait --for=condition=complete job/keycloak-frontend-client-setup \
+	$(KUBECTL_BIN) delete job keycloak-frontend-client-setup -n $(NAMESPACE_KC) --ignore-not-found
+	PORT_LANDING=$(PORT_LANDING) LANDING_HOST=$(LANDING_HOST) envsubst '$${PORT_LANDING} $${LANDING_HOST}' < dev/keycloak/frontend-client-job.yaml | $(KUBECTL_BIN) apply -f -
+	$(KUBECTL_BIN) wait --for=condition=complete job/keycloak-frontend-client-setup \
 	  -n $(NAMESPACE_KC) --timeout=3m
 	@echo "→  Writing nebari-landing-oauth2-proxy Secret (Helm chart oauth2-proxy input) …"
-	kubectl create namespace $(NAMESPACE_APP) --dry-run=client -o yaml | kubectl apply -f -
-	kubectl create secret generic nebari-landing-oauth2-proxy \
+	$(KUBECTL_BIN) create namespace $(NAMESPACE_APP) --dry-run=client -o yaml | $(KUBECTL_BIN) apply -f -
+	$(KUBECTL_BIN) create secret generic nebari-landing-oauth2-proxy \
 	  --namespace $(NAMESPACE_APP) \
 	  --from-literal=client-secret=nebari-frontend-dev-secret \
 	  --from-literal=cookie-secret=$$(openssl rand -hex 16) \
-	  --dry-run=client -o yaml | kubectl apply -f -
+	  --dry-run=client -o yaml | $(KUBECTL_BIN) apply -f -
 	@echo "✔  Keycloak nebari-landingpage client ready"
 
 # ── ArgoCD Application manifests ─────────────────────────────────────────────
@@ -362,28 +405,28 @@ frontend-client:
 ## The webapi is now managed by the Helm chart (make install)
 operator-install:
 	@echo "→  Deploying nebari-operator controller …"
-	kubectl create namespace $(NAMESPACE_OPERATOR) --dry-run=client -o yaml | kubectl apply -f -
-	kubectl create namespace $(NAMESPACE_APP)      --dry-run=client -o yaml | kubectl apply -f -
-	kubectl label namespace $(NAMESPACE_APP) nebari.dev/managed=true --overwrite
-	kubectl apply -k dev/manifests/nebari-operator/operator
-	kubectl rollout status deployment/nebari-operator-controller-manager -n $(NAMESPACE_OPERATOR) --timeout=5m
+	$(KUBECTL_BIN) create namespace $(NAMESPACE_OPERATOR) --dry-run=client -o yaml | $(KUBECTL_BIN) apply -f -
+	$(KUBECTL_BIN) create namespace $(NAMESPACE_APP)      --dry-run=client -o yaml | $(KUBECTL_BIN) apply -f -
+	$(KUBECTL_BIN) label namespace $(NAMESPACE_APP) nebari.dev/managed=true --overwrite
+	$(KUBECTL_BIN) apply -k dev/manifests/nebari-operator/operator
+	$(KUBECTL_BIN) rollout status deployment/nebari-operator-controller-manager -n $(NAMESPACE_OPERATOR) --timeout=5m
 	@echo "✔  nebari-operator controller deployed"
 
 ## operator-uninstall: remove the operator controller
 operator-uninstall:
-	-kubectl delete -k dev/manifests/nebari-operator/operator --ignore-not-found
+	-$(KUBECTL_BIN) delete -k dev/manifests/nebari-operator/operator --ignore-not-found
 	@echo "✔  nebari-operator controller removed"
 
 ## test-apps: apply sample NebariApp CRs to populate the webapi service cache
 test-apps:
 	@echo "→  Applying test NebariApp resources …"
-	kubectl apply -f dev/manifests/test-nebariapps.yaml
+	$(KUBECTL_BIN) apply -f dev/manifests/test-nebariapps.yaml
 	@echo "✔  Test NebariApps applied"
 
 ## argocd-apps: apply the rendered ArgoCD Application manifests
 argocd-apps:
 	@echo "→  Applying ArgoCD Application manifests …"
-	kubectl apply -f dev/manifests/argocd/
+	$(KUBECTL_BIN) apply -f dev/manifests/argocd/
 	@echo "✔  ArgoCD Application manifests applied"
 
 # ── Landing page ──────────────────────────────────────────────────────────────
@@ -391,26 +434,26 @@ argocd-apps:
 ## install: deploy nebari-landing via Helm chart (webapi + frontend + Redis)
 install:
 	@echo "→  Deploying nebari-landing Helm chart (release: $(HELM_RELEASE)) …"
-	kubectl create namespace $(NAMESPACE_APP) --dry-run=client -o yaml | kubectl apply -f -
-	helm dependency build charts/nebari-landing
-	helm upgrade --install $(HELM_RELEASE) charts/nebari-landing \
+	$(KUBECTL_BIN) create namespace $(NAMESPACE_APP) --dry-run=client -o yaml | $(KUBECTL_BIN) apply -f -
+	$(HELM_BIN) dependency build charts/nebari-landing
+	$(HELM_BIN) upgrade --install $(HELM_RELEASE) charts/nebari-landing \
 	  --namespace $(NAMESPACE_APP) \
 	  --values dev/chart-values.yaml \
 	  --wait --timeout 5m
 	# Force pods to restart so pullPolicy:Never always picks up the freshly loaded :dev image.
 	# This is a no-op on first install (pods already started above) but essential on re-runs.
-	-kubectl rollout restart deployment/$(HELM_RELEASE)-webapi    -n $(NAMESPACE_APP) 2>/dev/null || true
-	-kubectl rollout restart deployment/$(HELM_RELEASE)-frontend  -n $(NAMESPACE_APP) 2>/dev/null || true
-	-kubectl rollout status  deployment/$(HELM_RELEASE)-webapi    -n $(NAMESPACE_APP) --timeout=2m 2>/dev/null || true
-	-kubectl rollout status  deployment/$(HELM_RELEASE)-frontend  -n $(NAMESPACE_APP) --timeout=2m 2>/dev/null || true
+	-$(KUBECTL_BIN) rollout restart deployment/$(HELM_RELEASE)-webapi    -n $(NAMESPACE_APP) 2>/dev/null || true
+	-$(KUBECTL_BIN) rollout restart deployment/$(HELM_RELEASE)-frontend  -n $(NAMESPACE_APP) 2>/dev/null || true
+	-$(KUBECTL_BIN) rollout status  deployment/$(HELM_RELEASE)-webapi    -n $(NAMESPACE_APP) --timeout=2m 2>/dev/null || true
+	-$(KUBECTL_BIN) rollout status  deployment/$(HELM_RELEASE)-frontend  -n $(NAMESPACE_APP) --timeout=2m 2>/dev/null || true
 	@echo "✔  nebari-landing deployed in namespace '$(NAMESPACE_APP)'"
 
 ## uninstall: remove deployed resources (does not delete the cluster)
 uninstall: operator-uninstall
-	-helm uninstall $(HELM_RELEASE) -n $(NAMESPACE_APP)
-	-kubectl delete job keycloak-realm-setup -n $(NAMESPACE_KC) --ignore-not-found
-	-helm uninstall $(HELM_RELEASE_KC) -n $(NAMESPACE_KC)
-	-helm uninstall postgresql           -n $(NAMESPACE_KC)
+	-$(HELM_BIN) uninstall $(HELM_RELEASE) -n $(NAMESPACE_APP)
+	-$(KUBECTL_BIN) delete job keycloak-realm-setup -n $(NAMESPACE_KC) --ignore-not-found
+	-$(HELM_BIN) uninstall $(HELM_RELEASE_KC) -n $(NAMESPACE_KC)
+	-$(HELM_BIN) uninstall postgresql           -n $(NAMESPACE_KC)
 
 ## dev-watch: swap the Helm-managed frontend pod to a Vite HMR dev server.
 ## Applies dev/patches/frontend-dev-watch.yaml via 'kubectl patch --type=strategic'
@@ -465,16 +508,16 @@ print('   Mount PID', p.pid, '— log: /tmp/minikube-mount-frontend.log'); \
 	  exit 1; \
 	fi
 	@echo "→  Patching Helm deployment to Vite HMR (dev/patches/frontend-dev-watch.yaml) …"
-	kubectl patch deployment $(HELM_RELEASE)-frontend \
+	$(KUBECTL_BIN) patch deployment $(HELM_RELEASE)-frontend \
 	  -n $(NAMESPACE_APP) \
 	  --type=strategic \
 	  --patch-file dev/patches/frontend-dev-watch.yaml
 	@echo "   Deleting pods so the new spec takes effect immediately …"
-	@kubectl -n $(NAMESPACE_APP) delete pod -l app.kubernetes.io/component=frontend 2>/dev/null || true
+	@$(KUBECTL_BIN) -n $(NAMESPACE_APP) delete pod -l app.kubernetes.io/component=frontend 2>/dev/null || true
 	@echo "   Waiting for Vite pod to become ready (~2-3 min for npm install + Vite startup) …"
-	kubectl rollout status deployment/$(HELM_RELEASE)-frontend -n $(NAMESPACE_APP) --timeout=8m
+	$(KUBECTL_BIN) rollout status deployment/$(HELM_RELEASE)-frontend -n $(NAMESPACE_APP) --timeout=8m
 	@pkill -f "kubect[l].*port-forward.*$(HELM_RELEASE)-frontend" 2>/dev/null || true
-	@nohup kubectl -n $(NAMESPACE_APP) port-forward svc/$(HELM_RELEASE)-frontend $(PORT_LANDING):4180 \
+	@nohup $(KUBECTL_BIN) -n $(NAMESPACE_APP) port-forward svc/$(HELM_RELEASE)-frontend $(PORT_LANDING):4180 \
 	  > /tmp/pf-landing.log 2>&1 &
 	@sleep 1
 	@echo ""
@@ -498,9 +541,9 @@ stop-dev-watch:
 	     && echo "   iptables rule removed" || echo "   (rule was not present)"; \
 	 fi
 	@echo "→  Deleting patched frontend deployment so helm recreates it cleanly …"
-	@kubectl delete deployment $(HELM_RELEASE)-frontend -n $(NAMESPACE_APP) --ignore-not-found
+	@$(KUBECTL_BIN) delete deployment $(HELM_RELEASE)-frontend -n $(NAMESPACE_APP) --ignore-not-found
 	@echo "→  Restoring Helm-managed nginx frontend (helm upgrade) …"
-	helm upgrade $(HELM_RELEASE) charts/nebari-landing \
+	$(HELM_BIN) upgrade $(HELM_RELEASE) charts/nebari-landing \
 	  --namespace $(NAMESPACE_APP) \
 	  --values dev/chart-values.yaml \
 	  --wait --timeout 5m
@@ -532,25 +575,25 @@ dev-watch-status:
 	fi
 	@echo ""
 	@echo "── 3. pod status ──────────────────────────────────────────────"
-	@kubectl -n $(NAMESPACE_APP) get pods -l app.kubernetes.io/component=frontend -o wide 2>/dev/null || echo "   (no pods found)"
+	@$(KUBECTL_BIN) -n $(NAMESPACE_APP) get pods -l app.kubernetes.io/component=frontend -o wide 2>/dev/null || echo "   (no pods found)"
 	@echo ""
 	@echo "── 4. init container logs (wait-for-mount, last 30 lines) ─────"
-	@POD=$$(kubectl -n $(NAMESPACE_APP) get pods -l app.kubernetes.io/component=frontend \
+	@POD=$$($(KUBECTL_BIN) -n $(NAMESPACE_APP) get pods -l app.kubernetes.io/component=frontend \
 	          --field-selector=status.phase=Running \
 	          -o jsonpath='{.items[0].metadata.name}' 2>/dev/null); \
 	 if [ -n "$$POD" ]; then \
-	   kubectl -n $(NAMESPACE_APP) logs $$POD -c wait-for-mount --tail=30 2>/dev/null \
+	   $(KUBECTL_BIN) -n $(NAMESPACE_APP) logs $$POD -c wait-for-mount --tail=30 2>/dev/null \
 	     || echo "   (init container has already completed — no logs)"; \
 	 else \
 	   echo "   (no Running pod found)"; \
 	 fi
 	@echo ""
 	@echo "── 5. Vite container logs (frontend, last 40 lines) ───────────"
-	@POD=$$(kubectl -n $(NAMESPACE_APP) get pods -l app.kubernetes.io/component=frontend \
+	@POD=$$($(KUBECTL_BIN) -n $(NAMESPACE_APP) get pods -l app.kubernetes.io/component=frontend \
 	          --field-selector=status.phase=Running \
 	          -o jsonpath='{.items[0].metadata.name}' 2>/dev/null); \
 	 if [ -n "$$POD" ]; then \
-	   kubectl -n $(NAMESPACE_APP) logs $$POD -c frontend --tail=40 2>/dev/null; \
+	   $(KUBECTL_BIN) -n $(NAMESPACE_APP) logs $$POD -c frontend --tail=40 2>/dev/null; \
 	 else \
 	   echo "   (no Running pod found)"; \
 	 fi
@@ -626,16 +669,16 @@ port-forward:
 	@echo "→  (Re)starting port-forwards in the background …"
 	@pkill -f "kubect[l].*port-forward.*keycloak-keycloakx-http" 2>/dev/null || true
 	@pkill -f "kubect[l].*port-forward.*(nebari-landing-webapi|nebari-landing-frontend)" 2>/dev/null || true
-	@nohup kubectl -n $(NAMESPACE_KC)  port-forward svc/keycloak-keycloakx-http        $(PORT_KEYCLOAK):80   > /tmp/pf-keycloak.log 2>&1 &
-	@nohup kubectl -n $(NAMESPACE_APP) port-forward svc/$(HELM_RELEASE)-webapi          $(PORT_WEBAPI):8080  > /tmp/pf-webapi.log 2>&1 &
-	@nohup kubectl -n $(NAMESPACE_APP) port-forward svc/$(HELM_RELEASE)-frontend        $(PORT_LANDING):4180 > /tmp/pf-landing.log 2>&1 &
+	@nohup $(KUBECTL_BIN) -n $(NAMESPACE_KC)  port-forward svc/keycloak-keycloakx-http        $(PORT_KEYCLOAK):80   > /tmp/pf-keycloak.log 2>&1 &
+	@nohup $(KUBECTL_BIN) -n $(NAMESPACE_APP) port-forward svc/$(HELM_RELEASE)-webapi          $(PORT_WEBAPI):8080  > /tmp/pf-webapi.log 2>&1 &
+	@nohup $(KUBECTL_BIN) -n $(NAMESPACE_APP) port-forward svc/$(HELM_RELEASE)-frontend        $(PORT_LANDING):4180 > /tmp/pf-landing.log 2>&1 &
 	@sleep 2
 	@echo "✔  Port-forwards active (logs: /tmp/pf-*.log):"
 	@echo "     Keycloak   : http://localhost:$(PORT_KEYCLOAK)/auth"
 	@echo "     WebAPI     : http://localhost:$(PORT_WEBAPI)/api/v1/services"
 	@echo "     Landing    : http://localhost:$(PORT_LANDING)/"
 
-## stop-port-forward: kill all background kubectl port-forward processes
+## stop-port-forward: kill all background $(KUBECTL_BIN) port-forward processes
 stop-port-forward:
 	@pkill -f "kubect[l].*port-forward.*keycloak-keycloakx-http" 2>/dev/null && echo "✔  Killed Keycloak port-forward" || true
 	@pkill -f "kubect[l].*port-forward.*(nebari-landing-webapi|nebari-landing-frontend)" 2>/dev/null && echo "✔  Killed app port-forwards" || true


### PR DESCRIPTION
## Summary

Extends the existing minikube auto-download pattern to cover **kubectl** and **helm**.  
After this change the only manual prerequisite for `make setup` is **docker**.

## Changes

| File | What changed |
|------|---|
| `dev/Makefile` | New `KUBECTL_VERSION` / `HELM_VERSION` pinned variables + download URLs; `_kubectl` and `_helm` bootstrap targets; `KUBECTL_BIN` / `HELM_BIN` resolved vars (prefer system binary, fall back to `.bin/`); all recipe-level `kubectl`/`helm` calls updated to use the resolved vars; `deps-check` updated |
| `.gitignore` | Added `.bin/` |

## How it works

- `_kubectl`: checks `command -v kubectl`; if absent, downloads the static binary from `dl.k8s.io/release/$(KUBECTL_VERSION)/bin/$(OS)/$(ARCH)/kubectl` into `.bin/`.
- `_helm`: checks `command -v helm`; if absent, downloads the release tarball from `get.helm.sh` and extracts only the `helm` binary into `.bin/`.
- Both targets are no-ops if the tool is already present (either in PATH or previously downloaded).
- Versions can be overridden: `make setup KUBECTL_VERSION=v1.31.0 HELM_VERSION=v3.16.0`
- `setup` now depends on `_minikube _kubectl _helm` before `cluster-start`.