### PR TITLE
fix(keycloak): drop /auth context path everywhere (Keycloak 17+)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,7 +224,8 @@ kubectl logs -f deployment/webapi -c api -n nebari-system
 
 ## Release Process
 
-Releases are automated. See [docs/maintainers/release-checklist.md](docs/maintainers/release-checklist.md) for maintainer instructions.
+Releases are automated. See [docs/maintainers/release-checklist.md](docs/maintainers/release-checklist.md) for
+maintainer instructions.
 
 ## Getting Help
 

--- a/README.md
+++ b/README.md
@@ -23,20 +23,18 @@
   href="https://github.com/nebari-dev/nebari-landing/blob/main/LICENSE"><img
   src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License"></a> <a
   href="https://github.com/nebari-dev/nebari-landing/releases/latest"><img
-  src="https://img.shields.io/github/v/release/nebari-dev/nebari-landing?logo=github&label=release" alt="Latest Release"></a> <a href="https://golang.org"><img
+  src="https://img.shields.io/github/v/release/nebari-dev/nebari-landing?logo=github&label=release" alt="Latest
+  Release"></a> <a href="https://golang.org"><img
   src="https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go&logoColor=white" alt="Go 1.25+"></a> <a
   href="https://react.dev"><img src="https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black" alt="React
   19"></a>
 </p>
 
 <p align="center">
-  <a href="#architecture">Architecture</a> &middot;
-  <a href="#quick-start">Quick Start</a> &middot;
-  <a href="#helm-install">Helm Install</a> &middot;
-  <a href="#development">Development</a> &middot;
-  <a href="docs/api.md">API Reference</a> &middot;
-  <a href="dev/QUICKSTART.md">Local Dev Guide</a> &middot;
-  <a href="CONTRIBUTING.md">Contributing</a>
+  <a href="#architecture">Architecture</a> &middot; <a href="#quick-start">Quick Start</a> &middot; <a
+  href="#helm-install">Helm Install</a> &middot; <a href="#development">Development</a> &middot; <a
+  href="docs/api.md">API Reference</a> &middot; <a href="dev/QUICKSTART.md">Local Dev Guide</a> &middot; <a
+  href="CONTRIBUTING.md">Contributing</a>
 </p>
 
 
@@ -80,7 +78,8 @@ of NIC's foundational software. Two components work together:
 
 Both pods are deployed via the `charts/nebari-landing` Helm chart, typically managed by ArgoCD through NIC.
 
-Release artifacts — the Go webapi binary (linux/darwin, amd64/arm64) and the packaged Helm chart — are attached to every [GitHub release](https://github.com/nebari-dev/nebari-landing/releases) via GoReleaser.
+Release artifacts — the Go webapi binary (linux/darwin, amd64/arm64) and the packaged Helm chart — are attached to every
+[GitHub release](https://github.com/nebari-dev/nebari-landing/releases) via GoReleaser.
 
 ## Key Features
 
@@ -94,7 +93,8 @@ Release artifacts — the Go webapi binary (linux/darwin, amd64/arm64) and the p
 
 ## Helm Install
 
-> **Note**: In a full Nebari / NIC deployment the chart is managed by the Nebari Operator and ArgoCD — you do not need to install it manually.
+> **Note**: In a full Nebari / NIC deployment the chart is managed by the Nebari Operator and ArgoCD — you do not need
+> to install it manually.
 
 ### Add the Helm repository
 
@@ -116,7 +116,7 @@ helm upgrade --install nebari-landing nebari/nebari-landing \
 
 See [`charts/nebari-landing/values.yaml`](charts/nebari-landing/values.yaml) for the full set of configurable values.
 
----
+
 
 ## Quick Start
 
@@ -177,8 +177,9 @@ npm ci
 npm run dev
 ```
 
-> **Note**: `npm run dev` serves the SPA at `http://localhost:5173` but does **not** proxy `/api/*` calls — those require a running webapi.
-> For a fully connected local dev loop (Keycloak + webapi + frontend with hot-reload) use the dev cluster described in [dev/QUICKSTART.md](dev/QUICKSTART.md).
+> **Note**: `npm run dev` serves the SPA at `http://localhost:5173` but does **not** proxy `/api/*` calls — those
+> require a running webapi. For a fully connected local dev loop (Keycloak + webapi + frontend with hot-reload) use the
+> dev cluster described in [dev/QUICKSTART.md](dev/QUICKSTART.md).
 
 ## Development
 

--- a/charts/nebari-landing/values.yaml
+++ b/charts/nebari-landing/values.yaml
@@ -29,8 +29,8 @@ frontend:
   # by the frontend ConfigMap. The frontend fetches this file at startup so
   # the image is config-agnostic (no build-time VITE_* args needed).
   keycloak:
-    # Full Keycloak base URL including the /auth path.
-    # e.g. https://keycloak.example.com/auth
+    # Full Keycloak base URL (Keycloak 17+ no longer uses /auth as a context root).
+    # e.g. https://keycloak.example.com
     url: ""
     realm: "nebari"
     # OIDC client ID sent by the Keycloak JS adapter in the browser.
@@ -155,7 +155,7 @@ webapi:
 
   # Keycloak JWT validation.
   keycloak:
-    url: ""           # http://keycloak-keycloakx-http.keycloak.svc:8080/auth
+    url: ""           # http://keycloak-keycloakx-http.keycloak.svc:8080
     realm: "nebari"
     issuerUrl: ""     # overrides `url` for `iss` claim validation when different
     enableAuth: true

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -82,7 +82,7 @@ func main() {
 		"Port to listen on (env: PORT)")
 	// Note: controller-runtime registers --kubeconfig in its own init(); use ctrl.GetConfig() below.
 	flag.StringVar(&keycloakURL, "keycloak-url", os.Getenv("KEYCLOAK_URL"),
-		"Keycloak base URL for JWK fetching, e.g. http://keycloak-internal:8080/auth (env: KEYCLOAK_URL)")
+		"Keycloak base URL for JWK fetching, e.g. http://keycloak-internal:8080 (env: KEYCLOAK_URL)")
 	flag.StringVar(&keycloakRealm, "keycloak-realm", envStr("KEYCLOAK_REALM", "main"),
 		"Keycloak realm name (env: KEYCLOAK_REALM)")
 	flag.BoolVar(&enableAuth, "enable-auth", envBool("ENABLE_AUTH", false),

--- a/deploy/manifest.yaml
+++ b/deploy/manifest.yaml
@@ -40,9 +40,9 @@ spec:
                     - name: ENABLE_AUTH
                       value: "true"
                     - name: KEYCLOAK_URL
-                      value: http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/auth
+                      value: http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080
                     - name: KEYCLOAK_ISSUER_URL
-                      value: http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/auth/realms/nebari
+                      value: http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/realms/nebari
                     - name: KEYCLOAK_REALM
                       value: nebari
                     # Keycloak admin credentials — same Secret + namespace as the operator.

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -331,7 +331,7 @@ keycloak-install:
 	$(HELM_BIN) repo add codecentric $(KEYCLOAK_CHART) --force-update
 	@MINIKUBE_IP=$$($(MINIKUBE_BIN) ip -p $(CLUSTER_NAME)); \
 	 SUBNET=$$(echo "$$MINIKUBE_IP" | sed 's/\.[0-9]*$$//'); \
-	 export KC_HOSTNAME_URL="http://localhost:8180/auth"; \
+	 export KC_HOSTNAME_URL="http://localhost:8180"; \
 	 echo "→  Keycloak public URL (KC_HOSTNAME_URL): $$KC_HOSTNAME_URL"; \
 	 envsubst < dev/keycloak/values.yaml | \
 	 $(HELM_BIN) upgrade --install $(HELM_RELEASE_KC) codecentric/$(KEYCLOAK_CHART_NAME) \
@@ -636,7 +636,7 @@ info:
 	 echo "║    http://$${API_IP}:8080/api/v1/health"; \
 	 echo "║"; \
 	 echo "║  Keycloak admin console:"; \
-	 echo "║    http://$${KC_IP}/auth/admin  (admin / $(KEYCLOAK_ADMIN_PASSWORD))"; \
+	 echo "║    http://$${KC_IP}/admin  (admin / $(KEYCLOAK_ADMIN_PASSWORD))"; \
 	 echo "║    Realm: $(KEYCLOAK_REALM)  /  test user: admin / $(REALM_ADMIN_PASSWORD)"; \
 	 echo "║"; \
 	 echo "║  Operator namespace : $(NAMESPACE_OPERATOR)"; \
@@ -644,7 +644,7 @@ info:
 	 echo "║  Integration tests:"; \
 	 echo "║    python3 dev/webapi_test.py \\"; \
 	 echo "║      --webapi-url http://$${API_IP}:8080 \\"; \
-	 echo "║      --keycloak-url http://$${KC_IP}/auth \\"; \
+	 echo "║      --keycloak-url http://$${KC_IP} \\"; \
 	 echo "║      -u admin -p $(REALM_ADMIN_PASSWORD)"; \
 	 echo "║"; \
 	 echo "║  Hot-reload dev (Vite HMR via minikube mount):"; \
@@ -674,7 +674,7 @@ port-forward:
 	@nohup $(KUBECTL_BIN) -n $(NAMESPACE_APP) port-forward svc/$(HELM_RELEASE)-frontend        $(PORT_LANDING):4180 > /tmp/pf-landing.log 2>&1 &
 	@sleep 2
 	@echo "✔  Port-forwards active (logs: /tmp/pf-*.log):"
-	@echo "     Keycloak   : http://localhost:$(PORT_KEYCLOAK)/auth"
+	@echo "     Keycloak   : http://localhost:$(PORT_KEYCLOAK)"
 	@echo "     WebAPI     : http://localhost:$(PORT_WEBAPI)/api/v1/services"
 	@echo "     Landing    : http://localhost:$(PORT_LANDING)/"
 

--- a/dev/QUICKSTART.md
+++ b/dev/QUICKSTART.md
@@ -33,7 +33,7 @@ alias mk='make -f dev/Makefile'
 │                                                                                 │
 │  Browser → http://192.168.49.102/    (landing page + oauth2-proxy)             │
 │  curl    → http://192.168.49.101:8080/api/v1/services  (webapi)               │
-│  browser → http://192.168.49.100/auth/admin            (Keycloak UI)           │
+│  browser → http://192.168.49.100/admin                  (Keycloak UI)           │
 │                                                                                 │
 │               minikube cluster (docker driver, 4 CPU / 8 GB)                  │
 │  ┌─────────────────────────────────────────────────────────────────────────┐   │
@@ -78,8 +78,8 @@ alias mk='make -f dev/Makefile'
 ### Key design decisions
 
 **MetalLB instead of port-forwards** MetalLB assigns real IPs from `192.168.49.100–150` (inside minikube's docker bridge
-subnet). All three IPs are reachable from the host _and_ from pods, so the JWT `iss` claim
-(`http://192.168.49.100/auth/…`) is verifiable by both the browser and the webapi without any routing tricks.
+subnet). All three IPs are reachable from the host _and_ from pods, so the JWT `iss` claim (`http://192.168.49.100/…`)
+is verifiable by both the browser and the webapi without any routing tricks.
 
 **oauth2-proxy as a sidecar** The landing page container (nginx) doesn't know about authentication — that's
 OAuth2-proxy's job. oauth2-proxy runs on port 4180 next to nginx (port 8080) in the same pod. The LoadBalancer points at
@@ -166,7 +166,7 @@ the IPs in this guide stay valid. If you rename the cluster via `CLUSTER_NAME=�
 
 ```powershell
 # From PowerShell on Windows:
-curl http://192.168.49.100/auth/admin
+curl http://192.168.49.100/admin
 # Should return a redirect (302) — not a timeout
 ```
 
@@ -212,7 +212,7 @@ make -f dev/Makefile wsl-setup
 |---------|-----|
 | Landing page | `http://localhost:8080/` |
 | WebAPI | `http://localhost:8090/api/v1/` |
-| Keycloak admin | `http://localhost:8180/auth/admin` |
+| Keycloak admin | `http://localhost:8180/admin` |
 
 The port-forwards run in the background. Restart them at any time with:
 
@@ -223,7 +223,7 @@ make -f dev/Makefile stop-port-forward # stop
 
 **How it differs from the MetalLB setup** (see `dev/keycloak/values-wsl.yaml` and
 `dev/manifests/nebari-landingpage/overlays/wsl/`):
-- Keycloak `KC_HOSTNAME_URL=http://localhost:8180/auth` (the JWT `iss` matches the Windows-visible URL).
+- Keycloak `KC_HOSTNAME_URL=http://localhost:8180` (the JWT `iss` matches the Windows-visible URL).
 - `KC_HOSTNAME_BACKCHANNEL_DYNAMIC=true` — pods fetch Keycloak discovery via the cluster-internal service name; the
   returned `token_endpoint` / `jwks_uri` use that same internal hostname so back-channel calls never go through the
   forward.
@@ -265,7 +265,7 @@ back to the landing page.
 |---------|-----|-------------|
 | Landing page | `http://192.168.49.102/` | log in as `admin` / `nebari-realm-admin` |
 | WebAPI | `http://192.168.49.101:8080/api/v1/` | — |
-| Keycloak admin | `http://192.168.49.100/auth/admin` | `admin` / `nebari-admin-secret` |
+| Keycloak admin | `http://192.168.49.100/admin` | `admin` / `nebari-admin-secret` |
 
 
 
@@ -327,7 +327,7 @@ kustomize overlay and triggers a rolling restart.
 ```sh
 python3 dev/webapi_test.py \
   --webapi-url   http://192.168.49.101:8080 \
-  --keycloak-url http://192.168.49.100/auth \
+  --keycloak-url http://192.168.49.100 \
   -u admin -p nebari-realm-admin
 ```
 
@@ -459,7 +459,7 @@ SPA (in browser)
 | Realm | `nebari` |
 | Admin user | `admin` / `nebari-realm-admin` |
 | Admin group | `admin` (gives access to `visibility: private` services) |
-| OIDC issuer | `http://192.168.49.100/auth/realms/nebari` |
+| OIDC issuer | `http://192.168.49.100/realms/nebari` |
 | `webapi` client | public, direct grants — used by the test script |
 | `nebari-landingpage` client | confidential, standard flow — used by oauth2-proxy |
 | Client Secret (dev) | `nebari-frontend-dev-secret` (in k8s Secret `nebari-landingpage-oidc-client`) |
@@ -495,18 +495,18 @@ The `KEYCLOAK_ISSUER_URL` in the webapi must be the _base_ URL — the webapi ap
 kubectl get deploy webapi -n nebari-system \
   -o jsonpath='{.spec.template.spec.containers[0].env}' | python3 -m json.tool \
   | grep -A1 KEYCLOAK_ISSUER_URL
-# Should be: "http://192.168.49.100/auth"  (no /realms/nebari suffix)
+# Should be: "http://192.168.49.100"  (no /realms/nebari suffix)
 ```
 
 The JWT `iss` claim must exactly match what Keycloak's OIDC discovery returns. Check Keycloak's discovery:
 
 ```sh
-curl -s http://192.168.49.100/auth/realms/nebari/.well-known/openid-configuration \
+curl -s http://192.168.49.100/realms/nebari/.well-known/openid-configuration \
   | python3 -c "import sys,json; print(json.load(sys.stdin)['issuer'])"
-# Should be: http://192.168.49.100/auth/realms/nebari
+# Should be: http://192.168.49.100/realms/nebari
 ```
 
-If the discovery returns `http://localhost:8180/auth/realms/nebari` instead, Keycloak's `KC_HOSTNAME_URL` was set to the
+If the discovery returns `http://localhost:8180/realms/nebari` instead, Keycloak's `KC_HOSTNAME_URL` was set to the
 localhost port-forward URL. `make keycloak-install` now injects the correct MetalLB IP automatically via `envsubst`.
 Redeploy to fix it:
 
@@ -530,7 +530,7 @@ MetalLB v0.9.6 (minikube addon) uses a ConfigMap — not the newer CRD API. The 
 ### A kcadm Job is stuck / not completing
 
 All kcadm jobs connect to Keycloak on its cluster-internal service, which now listens on **port 80** (not 8080) after
-the Helm upgrade to LoadBalancer. The URL used is: `http://keycloak-keycloakx-http.keycloak.svc.cluster.local/auth`
+the Helm upgrade to LoadBalancer. The URL used is: `http://keycloak-keycloakx-http.keycloak.svc.cluster.local`
 
 If you need to run a job again:
 

--- a/dev/chart-values.yaml
+++ b/dev/chart-values.yaml
@@ -26,9 +26,9 @@ webapi:
 
   keycloak:
     # Cluster-internal URL for back-channel calls (JWKS fetch, admin API)
-    url: "http://keycloak-keycloakx-http.keycloak.svc.cluster.local/auth"
+    url: "http://keycloak-keycloakx-http.keycloak.svc.cluster.local"
     # Issuer URL that Keycloak stamps in JWTs (matches KC_HOSTNAME_URL in values.yaml)
-    issuerUrl: "http://localhost:8180/auth"
+    issuerUrl: "http://localhost:8180"
     realm: "nebari"
     enableAuth: true
     adminGroup: "admin"
@@ -72,13 +72,13 @@ frontend:
 
   keycloak:
     # Browser-visible Keycloak URL — exposed via port-forward at localhost:8180
-    url: "http://localhost:8180/auth"
+    url: "http://localhost:8180"
     realm: "nebari"
     clientId: "nebari-frontend-spa"
 
   oauth2Proxy:
     # Keycloak realm discovery endpoint — cluster-internal for the pod
-    oidcIssuerUrl: "http://keycloak-keycloakx-http.keycloak.svc.cluster.local/auth/realms/nebari"
+    oidcIssuerUrl: "http://keycloak-keycloakx-http.keycloak.svc.cluster.local/realms/nebari"
     clientId: "nebari-landingpage"
     # Secrets created by 'make frontend-client' — secret name: nebari-landing-oauth2-proxy
     # keys: client-secret (OIDC client secret) and cookie-secret (session encryption)

--- a/dev/create_notification.py
+++ b/dev/create_notification.py
@@ -17,23 +17,27 @@ import sys
 import requests
 
 # ── defaults (match dev/Makefile) ──────────────────────────────────────────────
-KC_URL      = "http://localhost:8180"
-KC_REALM    = "nebari"
-KC_CLIENT   = "webapi"          # must be the client with the groups mapper
-USERNAME    = "admin"
-PASSWORD    = "nebari-realm-admin"
-WEBAPI_URL  = "http://localhost:8090"
+KC_URL = "http://localhost:8180"
+KC_REALM = "nebari"
+KC_CLIENT = "webapi"  # must be the client with the groups mapper
+USERNAME = "admin"
+PASSWORD = "nebari-realm-admin"
+WEBAPI_URL = "http://localhost:8090"
 # ───────────────────────────────────────────────────────────────────────────────
 
 
 def get_token(kc_url: str, realm: str, client: str, username: str, password: str) -> str:
-    url = f"{kc_url}/auth/realms/{realm}/protocol/openid-connect/token"
-    resp = requests.post(url, data={
-        "grant_type": "password",
-        "client_id":  client,
-        "username":   username,
-        "password":   password,
-    }, timeout=10)
+    url = f"{kc_url}/realms/{realm}/protocol/openid-connect/token"
+    resp = requests.post(
+        url,
+        data={
+            "grant_type": "password",
+            "client_id": client,
+            "username": username,
+            "password": password,
+        },
+        timeout=10,
+    )
     resp.raise_for_status()
     return resp.json()["access_token"]
 
@@ -43,24 +47,29 @@ def create_notification(webapi_url: str, token: str, title: str, message: str, i
     body = {"title": title, "message": message}
     if image:
         body["image"] = image
-    resp = requests.post(url, json=body, headers={
-        "Authorization": f"Bearer {token}",
-    }, timeout=10)
+    resp = requests.post(
+        url,
+        json=body,
+        headers={
+            "Authorization": f"Bearer {token}",
+        },
+        timeout=10,
+    )
     resp.raise_for_status()
     return resp.json()
 
 
 def main():
     parser = argparse.ArgumentParser(description="Create a Nebari platform notification")
-    parser.add_argument("--kc-url",   default=KC_URL,      help="Keycloak base URL")
-    parser.add_argument("--realm",    default=KC_REALM,    help="Keycloak realm name")
-    parser.add_argument("--client",   default=KC_CLIENT,   help="Keycloak client_id (needs groups mapper)")
-    parser.add_argument("--username", default=USERNAME,    help="Realm user")
-    parser.add_argument("--password", default=PASSWORD,    help="Realm user password")
-    parser.add_argument("--webapi",   default=WEBAPI_URL,  help="webapi base URL")
-    parser.add_argument("--title",    default="Test notification", help="Notification title")
-    parser.add_argument("--message",  default="This is a test notification.", help="Notification body")
-    parser.add_argument("--image",    default="",           help="Optional image URL")
+    parser.add_argument("--kc-url", default=KC_URL, help="Keycloak base URL")
+    parser.add_argument("--realm", default=KC_REALM, help="Keycloak realm name")
+    parser.add_argument("--client", default=KC_CLIENT, help="Keycloak client_id (needs groups mapper)")
+    parser.add_argument("--username", default=USERNAME, help="Realm user")
+    parser.add_argument("--password", default=PASSWORD, help="Realm user password")
+    parser.add_argument("--webapi", default=WEBAPI_URL, help="webapi base URL")
+    parser.add_argument("--title", default="Test notification", help="Notification title")
+    parser.add_argument("--message", default="This is a test notification.", help="Notification body")
+    parser.add_argument("--image", default="", help="Optional image URL")
     args = parser.parse_args()
 
     print("→ Fetching token from Keycloak...")

--- a/dev/keycloak/frontend-client-job.yaml
+++ b/dev/keycloak/frontend-client-job.yaml
@@ -37,7 +37,7 @@ spec:
                   name: keycloak-admin-credentials
                   key: admin-password
             - name: KEYCLOAK_URL
-              value: http://keycloak-keycloakx-http.keycloak.svc.cluster.local/auth
+              value: http://keycloak-keycloakx-http.keycloak.svc.cluster.local
             # Static dev secret for the confidential oauth2-proxy client.
             # Safe only for local minikube; the operator generates a random one in prod.
             - name: CLIENT_SECRET

--- a/dev/keycloak/realm-setup-job.yaml
+++ b/dev/keycloak/realm-setup-job.yaml
@@ -25,7 +25,7 @@ spec:
                   name: nebari-realm-admin-credentials
                   key: password
             - name: KEYCLOAK_URL
-              value: http://keycloak-keycloakx-http.keycloak.svc.cluster.local/auth
+              value: http://keycloak-keycloakx-http.keycloak.svc.cluster.local
           command:
             - /bin/bash
             - -c

--- a/dev/keycloak/values.yaml
+++ b/dev/keycloak/values.yaml
@@ -46,17 +46,14 @@ extraEnv: |
   - name: KC_HOSTNAME_DEBUG
     value: "true"
 
-# Expose Keycloak under /auth — uses the chart's native key so the StatefulSet
-# only receives KC_HTTP_RELATIVE_PATH once (avoids "duplicate entries" helm error).
-http:
-  relativePath: "/auth"
-
+# Keycloak 17+ no longer uses /auth as a context root by default.
+# Do not set http.relativePath here — let Keycloak serve from /.
 proxy:
   enabled: false
 
 livenessProbe: |
   httpGet:
-    path: /auth/health/live
+    path: /health/live
     port: 8080
   initialDelaySeconds: 90
   periodSeconds: 10
@@ -65,7 +62,7 @@ livenessProbe: |
 
 readinessProbe: |
   httpGet:
-    path: /auth/health/ready
+    path: /health/ready
     port: 8080
   initialDelaySeconds: 60
   periodSeconds: 10
@@ -74,7 +71,7 @@ readinessProbe: |
 
 startupProbe: |
   httpGet:
-    path: /auth/health
+    path: /health
     port: 8080
   initialDelaySeconds: 60
   periodSeconds: 10

--- a/dev/keycloak/webapi-client-job.yaml
+++ b/dev/keycloak/webapi-client-job.yaml
@@ -21,7 +21,7 @@ spec:
                   name: keycloak-admin-credentials
                   key: admin-password
             - name: KEYCLOAK_URL
-              value: http://keycloak-keycloakx-http.keycloak.svc.cluster.local/auth
+              value: http://keycloak-keycloakx-http.keycloak.svc.cluster.local
           command:
             - /bin/bash
             - -c

--- a/dev/manifests/nebari-landingpage/overlays/dev/deployment-patch.yaml
+++ b/dev/manifests/nebari-landingpage/overlays/dev/deployment-patch.yaml
@@ -24,7 +24,7 @@ spec:
             - --http-address=0.0.0.0:4180
             - --upstream=http://localhost:8080
             # Keycloak realm discovery endpoint
-            - --oidc-issuer-url=http://192.168.49.100/auth/realms/nebari
+            - --oidc-issuer-url=http://192.168.49.100/realms/nebari
             - --insecure-oidc-skip-issuer-verification=true
             # --client-id is NOT set here; oauth2-proxy reads OAUTH2_PROXY_CLIENT_ID from env.
             # This keeps the arg list free of client-specific values and lets the

--- a/dev/manifests/nebari-operator/operator/deployment-patch.yaml
+++ b/dev/manifests/nebari-operator/operator/deployment-patch.yaml
@@ -12,7 +12,7 @@ spec:
             - name: KEYCLOAK_ENABLED
               value: "true"
             - name: KEYCLOAK_URL
-              value: "http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/auth"
+              value: "http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080"
             - name: KEYCLOAK_REALM
               value: "nebari"
             - name: KEYCLOAK_ADMIN_SECRET_NAME

--- a/dev/webapi_test.py
+++ b/dev/webapi_test.py
@@ -35,7 +35,7 @@ Enable debug mode in the webapi (restarts the pod):
 Usage:
     python dev/webapi_test.py
     python dev/webapi_test.py -u admin -p nebari-realm-admin
-    python dev/webapi_test.py --keycloak-url http://localhost:8180/auth
+    python dev/webapi_test.py --keycloak-url http://localhost:8180
     python dev/webapi_test.py --webapi-url http://localhost:8090 --path /api/v1/health
 """
 
@@ -51,7 +51,7 @@ except ImportError:
     sys.exit("Missing dependency: pip install requests")
 
 # ── Local defaults (port-forwarded) ───────────────────────────────────────────
-KEYCLOAK_URL = "http://localhost:8180/auth"
+KEYCLOAK_URL = "http://localhost:8180"
 WEBAPI_URL = "http://localhost:8090"
 DEFAULT_REALM = "nebari"
 DEFAULT_PATH = "/api/v1/services"
@@ -293,9 +293,7 @@ def run_pins(webapi_url: str, token: str, uid: Optional[str]) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Nebari WebAPI integration tests (local port-forward)")
-    parser.add_argument(
-        "--keycloak-url", default=KEYCLOAK_URL, help=f"Keycloak base URL with /auth (default: {KEYCLOAK_URL})"
-    )
+    parser.add_argument("--keycloak-url", default=KEYCLOAK_URL, help=f"Keycloak base URL (default: {KEYCLOAK_URL})")
     parser.add_argument("--webapi-url", default=WEBAPI_URL, help=f"WebAPI base URL (default: {WEBAPI_URL})")
     parser.add_argument("--realm", default=DEFAULT_REALM, help=f"Keycloak realm (default: {DEFAULT_REALM})")
     parser.add_argument("--path", default=None, help="Run a single ad-hoc GET against this path (skips test suite)")

--- a/frontend/public/config.json
+++ b/frontend/public/config.json
@@ -1,7 +1,7 @@
 {
   "keycloak": {
-    "url":      "http://localhost:8180/auth",
-    "realm":    "nebari",
+    "url": "http://localhost:8180",
+    "realm": "nebari",
     "clientId": "nebari-frontend-spa"
   }
 }

--- a/internal/auth/jwt_validator.go
+++ b/internal/auth/jwt_validator.go
@@ -88,7 +88,7 @@ func NewJWTValidator(keycloakURL, realm string) (*JWTValidator, error) {
 		log.Info("Failed to fetch Keycloak public keys, retrying",
 			"attempt", attempt, "maxRetries", retryMaxAttempts,
 			"backoff", backoff, "error", lastErr,
-			"hint", "verify KEYCLOAK_URL includes the context path (e.g. /auth for Keycloak X)")
+			"hint", "verify KEYCLOAK_URL is correct — Keycloak 17+ does not use /auth as a context root")
 		if attempt < retryMaxAttempts {
 			retryDelay(backoff)
 			backoff *= 2

--- a/internal/auth/jwt_validator_test.go
+++ b/internal/auth/jwt_validator_test.go
@@ -330,7 +330,7 @@ func withNoBackoff(t *testing.T, maxAttempts int) {
 }
 
 func TestNewJWTValidator_404_ReturnsError(t *testing.T) {
-	// Regression: KEYCLOAK_URL missing /auth context path causes HTTP 404.
+	// Regression: KEYCLOAK_URL pointing to a wrong endpoint returns HTTP 404.
 	withNoBackoff(t, 1)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -442,8 +442,8 @@ func TestSetIssuerURL_SetsURL(t *testing.T) {
 	key := generateTestKey(t)
 	srv := startJWKSServer(t, key)
 	v := newValidator(t, srv)
-	v.SetIssuerURL("https://keycloak.example.com/auth")
-	if v.issuerURL != "https://keycloak.example.com/auth" {
+	v.SetIssuerURL("https://keycloak.example.com")
+	if v.issuerURL != "https://keycloak.example.com" {
 		t.Errorf("expected issuerURL to be set, got %q", v.issuerURL)
 	}
 }

--- a/internal/keycloak/client.go
+++ b/internal/keycloak/client.go
@@ -8,7 +8,7 @@
 // operator (internal/config/auth.go) so that the same Deployment env block
 // works for both binaries:
 //
-//	KEYCLOAK_URL            – Keycloak base URL (all /auth traffic)
+//	KEYCLOAK_URL            – Keycloak base URL (Keycloak 17+; no /auth context root)
 //	KEYCLOAK_REALM          – target realm  (default: nebari)
 //	KEYCLOAK_ADMIN_USERNAME – master-realm admin username
 //	KEYCLOAK_ADMIN_PASSWORD – master-realm admin password
@@ -35,7 +35,7 @@ var log = ctrl.Log.WithName("keycloak-admin")
 
 // Config holds the credentials and target needed by Client.
 type Config struct {
-	// URL is the Keycloak base URL, e.g. http://keycloak:8080/auth
+	// URL is the Keycloak base URL, e.g. http://keycloak:8080
 	URL string
 	// Realm is the target realm in which users and groups are managed.
 	Realm string
@@ -51,12 +51,12 @@ type Config struct {
 // Required variables: KEYCLOAK_ADMIN_USERNAME, KEYCLOAK_ADMIN_PASSWORD
 // Optional:
 //
-//	KEYCLOAK_URL   (default: http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/auth)
+//	KEYCLOAK_URL   (default: http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080)
 //	KEYCLOAK_REALM (default: nebari)
 func ConfigFromEnv() (Config, error) {
 	url := os.Getenv("KEYCLOAK_URL")
 	if url == "" {
-		url = "http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/auth"
+		url = "http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080"
 	}
 	realm := os.Getenv("KEYCLOAK_REALM")
 	if realm == "" {
@@ -107,7 +107,7 @@ func NewFromEnv() (*Client, error) {
 func NewFromEnvWithK8sClient(ctx context.Context, k8sClient client.Client) (*Client, error) {
 	url := os.Getenv("KEYCLOAK_URL")
 	if url == "" {
-		url = "http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080/auth"
+		url = "http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080"
 	}
 	realm := os.Getenv("KEYCLOAK_REALM")
 	if realm == "" {

--- a/test/e2e/webapi_test.go
+++ b/test/e2e/webapi_test.go
@@ -158,7 +158,7 @@ var _ = Describe("Webapi – Service Discovery", Ordered, func() {
 		Expect(keycloakPFCmd.Start()).NotTo(HaveOccurred(), "keycloak port-forward should start")
 		var keycloakIssuer string
 		Eventually(func() error {
-			resp, err := http.Get(fmt.Sprintf("http://localhost:18090/auth/realms/%s/.well-known/openid-configuration", kcRealm))
+			resp, err := http.Get(fmt.Sprintf("http://localhost:18090/realms/%s/.well-known/openid-configuration", kcRealm))
 			if err != nil {
 				return err
 			}
@@ -175,7 +175,7 @@ var _ = Describe("Webapi – Service Discovery", Ordered, func() {
 			if disc.Issuer == "" {
 				return fmt.Errorf("OIDC discovery returned empty issuer")
 			}
-			// issuer looks like "http://<host>/auth/realms/<realm>";
+			// issuer looks like "http://<host>/realms/<realm>";
 			// strip the realm suffix to get the base URL for KEYCLOAK_ISSUER_URL.
 			keycloakIssuer = strings.TrimSuffix(disc.Issuer, fmt.Sprintf("/realms/%s", kcRealm))
 			return nil
@@ -217,7 +217,8 @@ var _ = Describe("Webapi – Service Discovery", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred(), "Failed to patch webapi container image")
 
 		By("Patching webapi deployment with discovered KEYCLOAK_ISSUER_URL")
-		// The issuer in tokens is set by KC_HOSTNAME_URL (e.g. http://<minikube-lb-ip>/auth).
+		// The issuer in tokens is set by KC_HOSTNAME_URL (e.g. http://<minikube-lb-ip>).
+		// Keycloak 17+ no longer uses /auth as a context root.
 		// The Helm chart value webapi.keycloak.issuerUrl may point to an in-cluster
 		// URL ≠ the token issuer.  Patch the live deployment so the JWT validator
 		// accepts tokens from this cluster regardless of the values file.
@@ -330,7 +331,7 @@ var _ = Describe("Webapi – Service Discovery", Ordered, func() {
 				"scope":      {"openid profile"},
 			}
 			tokenReq, err := http.NewRequest(http.MethodPost,
-				fmt.Sprintf("http://localhost:18090/auth/realms/%s/protocol/openid-connect/token", kcRealm),
+				fmt.Sprintf("http://localhost:18090/realms/%s/protocol/openid-connect/token", kcRealm),
 				strings.NewReader(tokenForm.Encode()))
 			Expect(err).NotTo(HaveOccurred())
 			tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -446,4 +447,3 @@ func serviceNames(r ServiceListResponse) []string {
 	}
 	return names
 }
-


### PR DESCRIPTION
## Summary
Since NIC will have the /auth endpoint suffix path removed (see [nebari-infrastructure-core#pull130](https://github.com/nebari-dev/nebari-infrastructure-core/pull/130)) from its foundational software configuration, realm URLs are now served at `<base>/realms/<realm>` and the admin console at `/admin` (not `/auth/admin`).

This PR removes every stale `/auth` URL prefix across the entire codebase — configuration, source code, tests, scripts, and documentation.

## Files changed

| Area | Files |
|---|---|
| Helm values | `charts/nebari-landing/values.yaml`, `dev/chart-values.yaml` |
| Keycloak jobs | `dev/keycloak/{frontend,webapi,realm-setup}-client-job.yaml` |
| Keycloak Helm values | `dev/keycloak/values.yaml` (remove `relativePath: /auth`; fix probe paths) |
| Manifests | `dev/manifests/*/deployment-patch.yaml`, `deploy/manifest.yaml` |
| Frontend config | `frontend/public/config.json` |
| Go source | `internal/keycloak/client.go`, `internal/auth/jwt_validator.go` |
| Go tests | `internal/auth/jwt_validator_test.go`, `test/e2e/webapi_test.go` |
| Entry point | `cmd/main.go` (flag help + GoReleaser version vars) |
| Scripts | `dev/webapi_test.py`, `dev/create_notification.py` |
| Dev tooling | `dev/Makefile` |
| Docs | `dev/QUICKSTART.md`, `README.md`, `CONTRIBUTING.md` |

## Additional changes

- Pin `oauth2-proxy` image to `v7.14.3` (was `latest`)
- Add `version`/`commit`/`date` vars in `cmd/main.go` for GoReleaser ldflags injection
- README: screenshot, Helm install section, badge, node 22+ prereq, `npm ci`, project structure
- CONTRIBUTING: correct Go version to 1.25
