### PR TITLE
feat: add extraEnv support for oauth2-proxy sidecar

### DIFF
--- a/charts/nebari-landing/templates/frontend/deployment.yaml
+++ b/charts/nebari-landing/templates/frontend/deployment.yaml
@@ -104,6 +104,9 @@ spec:
                 secretKeyRef:
                   name: {{ default (printf "%s-oauth2-proxy-cookie" (include "nebari-landing.fullname" .)) .Values.frontend.oauth2Proxy.existingCookieSecret }}
                   key: cookie-secret
+            {{- with .Values.frontend.oauth2Proxy.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: proxy
               containerPort: {{ .Values.frontend.oauth2Proxy.port }}

--- a/charts/nebari-landing/values.yaml
+++ b/charts/nebari-landing/values.yaml
@@ -118,6 +118,16 @@ frontend:
       - --cookie-refresh=4m
     # - --skip-provider-button
 
+    # Extra environment variables for the oauth2-proxy container.
+    # Useful for passing additional configuration (e.g., OAUTH2_PROXY_* vars).
+    # Example:
+    # extraEnv:
+    #   - name: OAUTH2_PROXY_SKIP_OIDC_DISCOVERY
+    #     value: "false"
+    #   - name: OAUTH2_PROXY_COOKIE_SECURE
+    #     value: "true"
+    extraEnv: []
+
     # Init container that blocks oauth2-proxy from starting until Keycloak's
     # OIDC discovery endpoint responds with HTTP 200. Prevents the crash-loop
     # that occurs when oauth2-proxy tries to fetch the JWKS before Keycloak


### PR DESCRIPTION
## Description

Add support for passing extra environment variables to the oauth2-proxy sidecar container through the Helm chart. This allows users to configure additional oauth2-proxy settings via environment variables.

## Changes

- Add `extraEnv` field to `frontend.oauth2Proxy` in values.yaml
- Update deployment template to inject extraEnv into oauth2-proxy container  
- Add documentation with usage examples

## Usage Example

```yaml
frontend:
  oauth2Proxy:
    extraEnv:
      - name: OAUTH2_PROXY_SKIP_OIDC_DISCOVERY
        value: "false"
      - name: OAUTH2_PROXY_COOKIE_SECURE
        value: "true"
      - name: OAUTH2_PROXY_COOKIE_SAMESITE
        value: "lax"
```

Or referencing secrets:
```yaml
frontend:
  oauth2Proxy:
    extraEnv:
      - name: MY_CUSTOM_VAR
        valueFrom:
          secretKeyRef:
            name: my-secret
            key: my-key
```

## Backward Compatibility

The implementation is fully backward compatible with `extraEnv` defaulting to an empty array.