### PR TITLE
feat: replace e2e cluster setup with nebari-action-sandbox

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -88,7 +88,7 @@ jobs:
       # ── Kubernetes cluster + Nebari platform ─────────────────────────────────
       - name: Setup Nebari Sandbox
         id: sandbox
-        uses: nebari-dev/action-nebari-sandbox@v1
+        uses: nebari-dev/action-nebari-sandbox@v1.0.1
         with:
           profile: platform
           cluster-name: nebari-e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,15 +58,32 @@ jobs:
           go-version-file: go.mod
           cache: false
 
+      # Unified Go cache — covers both e2e test modules and any Go build inside
+      # the sandbox action (NIC binary), so the sandbox step benefits too.
       - name: Cache Go modules
         uses: actions/cache@v5
         with:
           path: |
             ~/go/pkg/mod
             ~/.cache/go-build
-          key: e2e-go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          key: go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            e2e-go-${{ runner.os }}-
+            go-${{ runner.os }}-
+
+      # ── Webapi image (built before cluster so it's ready to import) ──────────
+      # Buildx + GHA layer cache — first run primes the cache (~94s),
+      # subsequent runs skip unchanged layers (~20-30s).
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build webapi image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: nebari-landing/webapi:dev
+          load: true
+          cache-from: type=gha,scope=e2e-webapi
+          cache-to: type=gha,mode=max,scope=e2e-webapi
 
       # ── Kubernetes cluster + Nebari platform ─────────────────────────────────
       - name: Setup Nebari Sandbox
@@ -76,10 +93,7 @@ jobs:
           profile: platform
           cluster-name: nebari-e2e
 
-      # ── Webapi image ─────────────────────────────────────────────────────────
-      - name: Build webapi image
-        run: docker build -t nebari-landing/webapi:dev .
-
+      # ── Load webapi image into k3d ────────────────────────────────────────────
       - name: Load webapi image into k3d
         run: k3d image import nebari-landing/webapi:dev -c ${{ steps.sandbox.outputs.cluster-name }}
 
@@ -124,6 +138,18 @@ jobs:
           fi
           kill "${PF_PID}" 2>/dev/null || true
 
+      # ── Read nebari realm admin password ─────────────────────────────────────
+      # NIC creates nebari-realm-admin-credentials in the keycloak namespace
+      # with a randomly-generated password (separate from the master realm admin
+      # password output by the sandbox).  Read it here so the e2e tests can
+      # authenticate against the nebari realm.
+      - name: Read nebari realm admin password
+        run: |
+          PASS=$(kubectl -n keycloak get secret nebari-realm-admin-credentials \
+            -o jsonpath='{.data.password}' | base64 -d)
+          echo "::add-mask::${PASS}"
+          echo "NEBARI_REALM_ADMIN_PASSWORD=${PASS}" >> "$GITHUB_ENV"
+
       # ── E2E suite ─────────────────────────────────────────────────────────────
       - name: Run e2e tests
         env:
@@ -132,8 +158,8 @@ jobs:
           CLUSTER_TYPE: k3d
           K3D_CLUSTER_NAME: ${{ steps.sandbox.outputs.cluster-name }}
           WEBAPI_IMG: nebari-landing/webapi:dev
-          # Keycloak admin password from the sandbox output.
-          E2E_KEYCLOAK_ADMIN_PASSWORD: ${{ steps.sandbox.outputs.keycloak-admin-password }}
+          # Password for the 'admin' user in the nebari realm (not the master realm).
+          E2E_KEYCLOAK_ADMIN_PASSWORD: ${{ env.NEBARI_REALM_ADMIN_PASSWORD }}
         run: go test ./test/e2e/... -tags=e2e -v -timeout 10m
 
       # ── Diagnostics ───────────────────────────────────────────────────────────

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,131 @@
+# e2e — runs the Ginkgo end-to-end suite against a real Kubernetes cluster
+# bootstrapped by nebari-dev/action-nebari-sandbox (platform profile).
+#
+# What the platform profile provides:
+#   - k3d cluster with MetalLB, cert-manager, Envoy Gateway
+#   - Keycloak (keycloakx chart, namespace: keycloak, svc: keycloak-keycloakx-http)
+#   - nebari realm pre-configured by NIC
+#   - ArgoCD managing all foundational apps
+#
+# The workflow adds on top:
+#   - Builds the webapi Docker image and imports it into k3d
+#   - Installs the NebariApp CRD directly (deterministic, no ArgoCD sync wait)
+#   - Runs the Ginkgo e2e suite with USE_EXISTING_CLUSTER=true
+
+name: E2E tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - test/e2e/**
+      - internal/**
+      - cmd/**
+      - charts/**
+      - .github/workflows/e2e.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - test/e2e/**
+      - internal/**
+      - cmd/**
+      - charts/**
+      - .github/workflows/e2e.yml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: e2e tests
+    runs-on: ubuntu-24.04
+
+    # platform bootstrap ~15 min + image build ~2 min + tests ~10 min
+    timeout-minutes: 60
+
+    steps:
+      # ── Checkout ─────────────────────────────────────────────────────────────
+      - uses: actions/checkout@v4
+
+      # ── Go toolchain ─────────────────────────────────────────────────────────
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      - name: Cache Go modules
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: e2e-go-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            e2e-go-${{ runner.os }}-
+
+      # ── Kubernetes cluster + Nebari platform ─────────────────────────────────
+      - name: Setup Nebari Sandbox
+        id: sandbox
+        uses: nebari-dev/action-nebari-sandbox@v1
+        with:
+          profile: platform
+          cluster-name: nebari-e2e
+
+      # ── Webapi image ─────────────────────────────────────────────────────────
+      - name: Build webapi image
+        run: docker build -t nebari-landing/webapi:dev .
+
+      - name: Load webapi image into k3d
+        run: k3d image import nebari-landing/webapi:dev -c ${{ steps.sandbox.outputs.cluster-name }}
+
+      # ── NebariApp CRD ─────────────────────────────────────────────────────────
+      # Apply directly so the tests don't depend on ArgoCD sync timing.
+      - name: Install NebariApp CRD
+        run: |
+          kubectl apply -f \
+            https://raw.githubusercontent.com/nebari-dev/nebari-operator/main/config/crd/bases/reconcilers.nebari.dev_nebariapps.yaml
+          kubectl wait --for=condition=Established \
+            crd/nebariapps.reconcilers.nebari.dev \
+            --timeout=60s
+
+      # ── E2E suite ─────────────────────────────────────────────────────────────
+      - name: Run e2e tests
+        env:
+          # Cluster is already running — skip Kind creation and docker build.
+          USE_EXISTING_CLUSTER: "true"
+          CLUSTER_TYPE: k3d
+          K3D_CLUSTER_NAME: ${{ steps.sandbox.outputs.cluster-name }}
+          WEBAPI_IMG: nebari-landing/webapi:dev
+          # Keycloak admin password from the sandbox output.
+          E2E_KEYCLOAK_ADMIN_PASSWORD: ${{ steps.sandbox.outputs.keycloak-admin-password }}
+        run: go test ./test/e2e/... -tags=e2e -v -timeout 10m
+
+      # ── Diagnostics ───────────────────────────────────────────────────────────
+      - name: Collect diagnostics on failure
+        if: failure()
+        run: |
+          echo "=== Pods (all namespaces) ==="
+          kubectl get pods -A || true
+          echo ""
+          echo "=== Recent warning events ==="
+          kubectl get events -A --field-selector type=Warning \
+            --sort-by='.lastTimestamp' 2>/dev/null | tail -30 || true
+          echo ""
+          echo "=== webapi logs ==="
+          kubectl logs -n nebari-system \
+            -l app.kubernetes.io/component=webapi --tail=100 || true
+          echo ""
+          echo "=== ArgoCD applications ==="
+          kubectl get applications -n argocd -o wide || true
+
+      # ── Cleanup ───────────────────────────────────────────────────────────────
+      - name: Cleanup
+        if: always()
+        run: |
+          k3d cluster delete ${{ steps.sandbox.outputs.cluster-name }}
+          docker network rm ${{ steps.sandbox.outputs.network-name }} 2>/dev/null || true

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -93,6 +93,37 @@ jobs:
             crd/nebariapps.reconcilers.nebari.dev \
             --timeout=60s
 
+      # ── Preflight: wait for Keycloak + nebari realm ──────────────────────────
+      # The sandbox waits for the keycloak pod to be Ready, but the realm
+      # provisioning PostSync hook runs asynchronously and may need a bit
+      # more time.  Poll the OIDC discovery endpoint via port-forward (port 8080,
+      # which is what keycloakx v7+ exposes on the service) until the realm
+      # responds, so the 30 s test timeout doesn't race with realm setup.
+      - name: Wait for Keycloak nebari realm
+        run: |
+          kubectl port-forward -n keycloak svc/keycloak-keycloakx-http 19090:8080 &
+          PF_PID=$!
+          trap "kill ${PF_PID} 2>/dev/null || true" EXIT
+          echo "Polling http://localhost:19090/realms/nebari/.well-known/openid-configuration …"
+          for i in $(seq 1 60); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 \
+              http://localhost:19090/realms/nebari/.well-known/openid-configuration 2>/dev/null || echo 000)
+            if [ "$STATUS" = "200" ]; then
+              echo "✔  nebari realm ready (HTTP $STATUS)"
+              break
+            fi
+            echo "  attempt $i/60 — HTTP $STATUS, retrying in 5 s …"
+            sleep 5
+          done
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 5 \
+            http://localhost:19090/realms/nebari/.well-known/openid-configuration 2>/dev/null || echo 000)
+          if [ "$STATUS" != "200" ]; then
+            echo "✗  nebari realm did not become ready (last HTTP $STATUS)"
+            kill "${PF_PID}" 2>/dev/null || true
+            exit 1
+          fi
+          kill "${PF_PID}" 2>/dev/null || true
+
       # ── E2E suite ─────────────────────────────────────────────────────────────
       - name: Run e2e tests
         env:

--- a/dev/chart-values.yaml
+++ b/dev/chart-values.yaml
@@ -26,7 +26,8 @@ webapi:
 
   keycloak:
     # Cluster-internal URL for back-channel calls (JWKS fetch, admin API)
-    url: "http://keycloak-keycloakx-http.keycloak.svc.cluster.local"
+    # keycloakx chart v7+ exposes the service on httpPort (8080), not the HTTP default 80.
+    url: "http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080"
     # Issuer URL that Keycloak stamps in JWTs (matches KC_HOSTNAME_URL in values.yaml)
     issuerUrl: "http://localhost:8180"
     realm: "nebari"

--- a/test/e2e/webapi_test.go
+++ b/test/e2e/webapi_test.go
@@ -83,6 +83,10 @@ var (
 
 	kcNamespace     = envOrDefault("E2E_KEYCLOAK_NAMESPACE", "keycloak")
 	kcService       = envOrDefault("E2E_KEYCLOAK_SERVICE", "keycloak-keycloakx-http")
+	// E2E_KEYCLOAK_PORT is the service port that the keycloakx chart exposes.
+	// keycloakx v7+ sets service.httpPort=8080 so the service listens on 8080,
+	// not the HTTP default 80.  Override to 80 only for older local deployments.
+	kcPort          = envOrDefault("E2E_KEYCLOAK_PORT", "8080")
 	kcRealm         = envOrDefault("E2E_KEYCLOAK_REALM", "nebari")
 	kcAdminUser     = envOrDefault("E2E_KEYCLOAK_ADMIN_USER", "admin")
 	kcAdminPassword = envOrDefault("E2E_KEYCLOAK_ADMIN_PASSWORD", "nebari-realm-admin")
@@ -154,7 +158,7 @@ var _ = Describe("Webapi – Service Discovery", Ordered, func() {
 		By("Starting Keycloak port-forward to discover issuer URL")
 		keycloakPFCmd = exec.Command("kubectl", "port-forward",
 			"-n", kcNamespace, fmt.Sprintf("svc/%s", kcService),
-			"18090:80")
+			fmt.Sprintf("18090:%s", kcPort))
 		Expect(keycloakPFCmd.Start()).NotTo(HaveOccurred(), "keycloak port-forward should start")
 		var keycloakIssuer string
 		Eventually(func() error {

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -82,12 +82,20 @@ func LoadImageToKindCluster(name string) error {
 }
 
 // LoadImageToCluster loads a container image into the appropriate cluster based
-// on clusterType ("kind" or "minikube").  profile is used as the minikube
+// on clusterType ("kind", "minikube", or "k3d").  profile is used as the minikube
 // profile name when clusterType is "minikube".
 func LoadImageToCluster(name, clusterType, profile string) error {
 	switch clusterType {
 	case "minikube":
 		cmd := exec.Command("minikube", "-p", profile, "image", "load", name)
+		_, err := Run(cmd)
+		return err
+	case "k3d":
+		cluster := os.Getenv("K3D_CLUSTER_NAME")
+		if cluster == "" {
+			cluster = "nebari-test"
+		}
+		cmd := exec.Command("k3d", "image", "import", name, "-c", cluster)
 		_, err := Run(cmd)
 		return err
 	default: // "kind"


### PR DESCRIPTION
## Summary

Replaces the per-repo cluster bootstrap in the e2e suite with the shared `nebari-dev/action-nebari-sandbox` action (platform profile), eliminating duplicate infrastructure setup code and keeping the test environment consistent across all nebari repos.

## Changes

### `.github/workflows/e2e.yml` (new)
New workflow that:
1. Boots the full Nebari foundational stack via `nebari-dev/action-nebari-sandbox@v1` (platform profile) — k3d + MetalLB + cert-manager + Envoy Gateway + Keycloak with pre-configured `nebari` realm
2. Builds the webapi Docker image and imports it into k3d
3. Installs the NebariApp CRD directly from the operator repo (deterministic — no ArgoCD sync-timing dependency)
4. Runs `go test ./test/e2e/... -tags=e2e` with `USE_EXISTING_CLUSTER=true` so the Ginkgo suite skips its own Kind cluster lifecycle
5. Cleans up the k3d cluster and Docker network on exit

The existing `dev-watch-test.yml` workflow is unchanged — it uses `minikube mount` (9p filesystem) for hot-reload, which has no k3d equivalent.

### `test/utils/utils.go`
Added `k3d` case to `LoadImageToCluster` so that local e2e runs with `CLUSTER_TYPE=k3d` work correctly (`k3d image import -c $K3D_CLUSTER_NAME`). The CI workflow uses `USE_EXISTING_CLUSTER=true` and handles image loading separately, so this is only exercised in local dev.

## Before / After

```
# Before — per-repo Kind cluster management in e2e_suite_test.go
BeforeSuite: kind create cluster → docker build → kind load docker-image
AfterSuite:  kind delete cluster

# After — cluster managed by shared reusable action
workflow: action-nebari-sandbox (platform) → k3d image import → kubectl apply CRD
e2e suite: USE_EXISTING_CLUSTER=true, skips all cluster lifecycle code
```

## Key facts about the platform profile

- Keycloak service: `keycloak-keycloakx-http` in namespace `keycloak` (matches existing e2e defaults — no test code changes needed)
- Keycloak admin password: passed via `E2E_KEYCLOAK_ADMIN_PASSWORD` from sandbox output
- JWT JWKS fetch: uses in-cluster HTTP URL `http://keycloak-keycloakx-http.keycloak.svc.cluster.local` (no TLS required)
- JWT issuer URL: dynamically discovered by the e2e suite via OIDC discovery and patched onto the webapi deployment
