### PR TITLE
chore: bump GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -17,7 +17,7 @@ jobs:
       PW_OUTPUT_DIR: playwright_temp
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/automated-accessibility.yml
+++ b/.github/workflows/automated-accessibility.yml
@@ -20,7 +20,7 @@ jobs:
       PW_OUTPUT_DIR: .playwright/artifacts
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/dev-watch-test.yml
+++ b/.github/workflows/dev-watch-test.yml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       # ── Checkout ────────────────────────────────────────────────────────────
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # ── minikube ────────────────────────────────────────────────────────────
       - name: Start minikube

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -48,7 +48,7 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:
@@ -70,7 +70,7 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:
@@ -93,7 +93,7 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:
@@ -119,7 +119,7 @@ jobs:
     name: Helm chart lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
@@ -145,10 +145,10 @@ jobs:
           - arch: arm64
             runner: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Quay.io
         id: login
@@ -172,7 +172,7 @@ jobs:
         if: >-
           steps.login.outcome == 'success' &&
           github.event_name != 'pull_request'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: frontend
           file: frontend/Dockerfile
@@ -205,7 +205,7 @@ jobs:
         if: >-
           steps.login.outcome == 'success' &&
           github.event_name == 'pull_request'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: frontend
           file: frontend/Dockerfile
@@ -219,7 +219,7 @@ jobs:
       # Build-only fallback when Quay secrets are absent (fork PRs) ──────────
       - name: Build image (no push)
         if: steps.login.outcome != 'success'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: frontend
           file: frontend/Dockerfile
@@ -238,7 +238,7 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Quay.io
         uses: docker/login-action@v3
@@ -292,7 +292,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Quay.io
         id: login

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
     name: Validate webapi
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v5
         with:
@@ -60,7 +60,7 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:
@@ -91,12 +91,12 @@ jobs:
           - arch: arm64
             runner: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Quay.io
         uses: docker/login-action@v3
@@ -107,7 +107,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile
@@ -147,12 +147,12 @@ jobs:
           - arch: arm64
             runner: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Quay.io
         uses: docker/login-action@v3
@@ -163,7 +163,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: frontend
           file: frontend/Dockerfile
@@ -196,7 +196,7 @@ jobs:
     needs: docker-webapi
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Quay.io
         uses: docker/login-action@v3
@@ -248,7 +248,7 @@ jobs:
     needs: docker-frontend
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Quay.io
         uses: docker/login-action@v3
@@ -299,7 +299,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: validate-webapi
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # GoReleaser needs full history for changelog
 
@@ -323,7 +323,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [manifest-webapi, manifest-frontend]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Helm
         uses: azure/setup-helm@v4

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       # ── Checkout (full history so we can push back) ──────────────────────────
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # Fetch full history; needed for git push back to the same branch.

--- a/.github/workflows/sync-helm-chart.yml
+++ b/.github/workflows/sync-helm-chart.yml
@@ -44,7 +44,7 @@ jobs:
       contents: read  # to check out this repository
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # ── Resolve the release tag ───────────────────────────────────────────
       # On release events use tag_name; on workflow_dispatch fall back to the

--- a/.github/workflows/webapi.yml
+++ b/.github/workflows/webapi.yml
@@ -60,7 +60,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v5
         with:
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v5
         with:
@@ -112,7 +112,7 @@ jobs:
     name: Helm chart lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
@@ -139,7 +139,7 @@ jobs:
             runner: ubuntu-24.04-arm
             goarch: arm64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v5
         with:
@@ -168,10 +168,10 @@ jobs:
           - arch: arm64
             runner: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Quay.io
         id: login
@@ -195,7 +195,7 @@ jobs:
         if: >-
           steps.login.outcome == 'success' &&
           github.event_name != 'pull_request'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile
@@ -228,7 +228,7 @@ jobs:
         if: >-
           steps.login.outcome == 'success' &&
           github.event_name == 'pull_request'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile
@@ -242,7 +242,7 @@ jobs:
       # Build-only fallback when Quay secrets are absent (fork PRs) ──────────
       - name: Build image (no push)
         if: steps.login.outcome != 'success'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile
@@ -261,7 +261,7 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Quay.io
         uses: docker/login-action@v3
@@ -315,7 +315,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Quay.io
         id: login


### PR DESCRIPTION
## Summary

Bump three GitHub Actions to versions that support the Node.js 24 runtime, ahead of GitHub's deprecation deadline (Node.js 20 forced off June 2026, removed September 2026).

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `v4` | `v6` |
| `docker/build-push-action` | `v6` | `v7` |
| `docker/setup-buildx-action` | `v3` | `v4` |

## Changes

### `.github/workflows/*.yml` (8 files)
- Global find-and-replace of all three action pins to their latest major versions
- No workflow logic changed

## Before / After

```
# Before (deprecation warning in every run)
Node.js 20 actions are deprecated. The following actions are running on Node.js 20
and may not work as expected: actions/checkout@v4, docker/build-push-action@v6,
docker/setup-buildx-action@v3.

# After
No deprecation warnings
```
