### PR TITLE
ci: temporarily disable dev-watch smoke test

### DIFF
--- a/.github/workflows/dev-watch-test.yml
+++ b/.github/workflows/dev-watch-test.yml
@@ -44,6 +44,9 @@ jobs:
   dev-watch-smoke:
     name: dev-watch smoke test
     runs-on: ubuntu-latest
+    # Temporarily disabled — Helm deploy step is broken due to work in progress
+    # tracked in issue #57. Re-enable once that issue is resolved.
+    if: false
 
     # Generous timeout — full cluster bootstrap takes ~15 min; npm install inside
     # the Vite pod adds ~3 min on top.


### PR DESCRIPTION
## Summary

Temporarily disables the dev-watch smoke test CI job while the underlying Helm deploy issue is resolved in #57.

## Changes

### `.github/workflows/dev-watch-test.yml`
- Added `if: false` to the `dev-watch-smoke` job with a comment pointing to #57

## Before / After

```bash
# Before — job runs and fails at "Deploy nebari-landing via Helm"

# After — job is skipped, unblocking PRs from a spurious failure
```

The workflow file is otherwise untouched. Removing the `if: false` line is all that's needed to re-enable it once #57 is resolved.
