### PR TITLE
docs: fix broken hero screenshot link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@
 </p>
 
 <p align="center">
-  <img src="docs/static/imgs/landingpage-overview.png" alt="Nebari Landing page overview" width="800">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/static/screenshots/homepage-dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="docs/static/screenshots/homepage-light.png">
+    <img src="docs/static/screenshots/homepage-light.png" alt="Nebari Landing page overview" width="800">
+  </picture>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- README's hero screenshot pointed to `docs/static/imgs/landingpage-overview.png`, which does not exist in the repo (the path was never added).
- The actual screenshots live at `docs/static/screenshots/homepage-{light,dark}.png` (kept in sync by the `docs: update frontend screenshots` automation).
- Switch to a `<picture>` element with light/dark `srcset` variants — mirrors the existing logo block at the top of the README.

## Test plan
- [x] Render preview on the PR page shows the screenshot in both light and dark modes.