### PR TITLE
ci(e2e): smart-resolve webapi tag with :latest fallback

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -70,26 +70,91 @@ jobs:
           restore-keys: |
             go-${{ runner.os }}-
 
-      # ── Webapi image tag (published by webapi.yml) ───────────────────────────
-      # webapi.yml uses different tagging schemes for the two event types:
-      #   - pull_request → quay.io/nebari/nebari-webapi:<branch-tag>
-      #     (sanitised head ref, set by the "manifest (PR)" job)
-      #   - push to main → quay.io/nebari/nebari-webapi:<short-sha> + :latest
-      #     (no branch-named tag is pushed on main, so falling back to the
-      #     short SHA matches what the upstream workflow actually publishes)
-      # Reuse whichever tag exists for the event we are running under so we
-      # are not building a second webapi locally.
-      - name: Compute webapi image tag
+      # ── Resolve and wait for the webapi image on Quay ────────────────────────
+      # webapi.yml triggers only on cmd/** and internal/** changes, while
+      # e2e.yml additionally triggers on charts/**, test/e2e/**, and
+      # .github/workflows/e2e.yml. For events that don't touch webapi-relevant
+      # files, webapi.yml is skipped — no per-event tag is published — and any
+      # naive wait against the expected tag would hang for the full timeout.
+      #
+      # Strategy:
+      #   1. Resolve the tag webapi.yml would publish for this event:
+      #        - pull_request → :<sanitised-head-ref>
+      #        - push         → :<short-sha>
+      #   2. Inspect the file diff for this event. If it contains any cmd/**
+      #      or internal/** path, webapi.yml is expected to build the tag —
+      #      wait up to 10 min for the manifest to appear.
+      #   3. Otherwise, webapi.yml will not run. Fall back to :latest
+      #      (the current main webapi), which is what the unmodified webapi
+      #      code in this PR/push would have used anyway.
+      - name: Resolve webapi image tag
         id: branch
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+          set -euo pipefail
+          EVENT="${GITHUB_EVENT_NAME}"
+          HEAD_SHA="${GITHUB_SHA}"
+
+          if [[ "$EVENT" == "pull_request" ]]; then
             BRANCH="${GITHUB_HEAD_REF}"
-            TAG=$(echo "$BRANCH" | sed 's/\//-/g' | sed 's/[^a-zA-Z0-9._-]//g')
+            EXPECTED_TAG=$(echo "$BRANCH" | sed 's/\//-/g' | sed 's/[^a-zA-Z0-9._-]//g')
           else
-            TAG="${GITHUB_SHA:0:7}"
+            EXPECTED_TAG="${HEAD_SHA:0:7}"
           fi
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "  resolved tag: $TAG (event: $GITHUB_EVENT_NAME)"
+          echo "  expected per-event tag: :$EXPECTED_TAG"
+
+          echo "::group::Inspect diff to predict whether webapi.yml will run"
+          if [[ "$EVENT" == "pull_request" ]]; then
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+            changed_files=$(gh api \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+              --paginate --jq '.[].filename')
+          else
+            BEFORE="${{ github.event.before }}"
+            if [[ -z "$BEFORE" || "$BEFORE" == "0000000000000000000000000000000000000000" ]]; then
+              # New ref or force-push without a meaningful "before" SHA —
+              # treat as if webapi-relevant files changed so we still wait
+              # for the freshly-built image. Conservative default.
+              changed_files="cmd/SENTINEL"
+            else
+              changed_files=$(gh api \
+                "repos/${GITHUB_REPOSITORY}/compare/${BEFORE}...${HEAD_SHA}" \
+                --jq '.files[].filename')
+            fi
+          fi
+          matches=$(printf '%s\n' "$changed_files" | grep -E '^(cmd|internal)/' || true)
+          if [[ -n "$matches" ]]; then
+            echo "  webapi-relevant changes detected:"
+            printf '    %s\n' $matches
+            webapi_will_build=true
+          else
+            echo "  no cmd/** or internal/** in diff — webapi.yml will be skipped"
+            webapi_will_build=false
+          fi
+          echo "::endgroup::"
+
+          if $webapi_will_build; then
+            TARGET="$EXPECTED_TAG"
+            MAX_ATTEMPTS=60   # 10 min, comfortably above webapi.yml's typical 3-5 min build
+            echo "  → waiting for :$TARGET (up to 10 min)"
+          else
+            TARGET="latest"
+            MAX_ATTEMPTS=6    # 1 min, :latest should already exist
+            echo "  → falling back to :$TARGET (1 min check)"
+          fi
+
+          for i in $(seq 1 $MAX_ATTEMPTS); do
+            if docker manifest inspect "quay.io/nebari/nebari-webapi:${TARGET}" >/dev/null 2>&1; then
+              echo "tag=$TARGET" >> "$GITHUB_OUTPUT"
+              echo "✔ resolved webapi image tag: :$TARGET"
+              exit 0
+            fi
+            echo "  attempt $i/$MAX_ATTEMPTS — :$TARGET not yet on Quay …"
+            sleep 10
+          done
+          echo "✗ :$TARGET never became available"
+          exit 1
 
       # ── Kubernetes cluster + Nebari platform ─────────────────────────────────
       # The image override below is applied via a Git commit to the local
@@ -102,25 +167,6 @@ jobs:
         with:
           profile: platform
           cluster-name: nebari-e2e
-
-      # ── Wait for the resolved webapi image on Quay ───────────────────────────
-      # webapi.yml runs in parallel with this workflow on the same SHA. Block
-      # here until its manifest job has published the tag (branch-named on PRs,
-      # short-SHA on main pushes) so the rollout step below has something to
-      # pull.
-      - name: Wait for webapi image on Quay
-        run: |
-          IMAGE="quay.io/nebari/nebari-webapi:${{ steps.branch.outputs.tag }}"
-          for i in $(seq 1 60); do
-            if docker manifest inspect "$IMAGE" >/dev/null 2>&1; then
-              echo "✔ $IMAGE is available"
-              exit 0
-            fi
-            echo "  attempt $i/60 — waiting for $IMAGE …"
-            sleep 10
-          done
-          echo "✗ $IMAGE never became available"
-          exit 1
 
       # ── NebariApp CRD ─────────────────────────────────────────────────────────
       # Apply directly so the tests don't depend on ArgoCD sync timing.


### PR DESCRIPTION
## Summary

PR #78 fixed one symptom (push-to-main waiting for a branch-named tag that never exists), but the underlying problem is broader: `e2e.yml` and `webapi.yml` have mismatched path filters.

| Workflow | Triggers on |
|---|---|
| `e2e.yml`    | `cmd/**`, `internal/**`, `charts/**`, `test/e2e/**`, `.github/workflows/e2e.yml` |
| `webapi.yml` | `cmd/**`, `internal/**`, `.github/workflows/webapi.yml` |

When an event touches only `charts/**`, `test/e2e/**`, or `.github/workflows/e2e.yml`, `webapi.yml` is skipped and no per-event tag is published. `e2e.yml` then waits the full timeout for an image that will never appear.

PR #78 itself was an instance: its merge to main (`e2bf5cd`) skipped `webapi.yml`, the e2e on main waited 10 min for `quay.io/nebari/nebari-webapi:e2bf5cd`, and failed.

## Fix

Fold the compute and wait steps into one "Resolve webapi image tag" step that:

1. Computes the expected per-event tag (branch-tag on PR, short SHA on push).
2. Queries the GH API for the file diff of this event (`/pulls/{n}/files` on PRs, `/compare/{before}...{after}` on push) and looks for any `cmd/**` or `internal/**` path. That mirrors `webapi.yml`'s path filter, predicting whether it will run.
3. If `webapi.yml` is expected to build, waits up to 10 min for the expected tag. If not, falls back to `:latest` after a 1 min sanity probe and exposes that as the resolved tag via `steps.branch.outputs.tag`.

The downstream override + rollout steps already read `steps.branch.outputs.tag`, so no other changes needed.

## Verification

| Scenario | Expected behaviour | What the new step does |
|---|---|---|
| PR with `cmd/` changes | wait for `:<branch-tag>` | predicts webapi build → waits 10 min |
| PR with chart-only changes | use `:latest` | predicts no build → falls back in 1 min |
| Push to main with `cmd/` changes | wait for `:<short-sha>` | predicts webapi build → waits 10 min |
| Push to main with chart-only changes | use `:latest` | predicts no build → falls back in 1 min |

Tested locally that `docker manifest inspect quay.io/nebari/nebari-webapi:e2bf5cd` returns missing (which would have hung the current step) and `:latest` exists (which the new fallback path uses).

## Edge case

For push events whose `before` SHA is missing or all-zeros (brand-new ref, force-push), the diff query has no meaningful base. The new step assumes webapi changed in that case and waits the full window — conservative but never wrong.

## Log readability

When this fires in a future run, the step output shows the decision explicitly:

```
expected per-event tag: :feat-foo
  webapi-relevant changes detected:
    cmd/main.go
    internal/api/handlers.go
  → waiting for :feat-foo (up to 10 min)
✔ resolved webapi image tag: :feat-foo
```

or:

```
expected per-event tag: :a1b2c3d
  no cmd/** or internal/** in diff — webapi.yml will be skipped
  → falling back to :latest (1 min check)
✔ resolved webapi image tag: :latest
```

So `git blame` + `gh run view` will tell anyone debugging exactly why the e2e suite is testing against a given webapi.