### PR TITLE
fix(auth): decouple JWKS init from HTTP server start (#85)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         run: go vet ./...
 
       - name: Unit tests
-        run: go test ./internal/... -count=1
+        run: go test ./internal/... -race -count=1
 
   # ── Validate frontend ──────────────────────────────────────────────────────
   validate-frontend:

--- a/.github/workflows/webapi.yml
+++ b/.github/workflows/webapi.yml
@@ -96,7 +96,9 @@ jobs:
         run: go vet ./...
 
       - name: Unit tests
-        run: go test ./internal/... -count=1 -coverprofile=coverage.out
+        # -race is on so concurrency bugs (e.g. unsynchronised shared state in
+        # tests that spawn goroutines) fail CI instead of someone's laptop.
+        run: go test ./internal/... -race -count=1 -coverprofile=coverage.out
 
       - name: Coverage summary
         run: go tool cover -func=coverage.out | tail -1

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ docs: generate-docs apicard gendocs ## Regenerate spec, SVG cards, and docs/api.
 
 .PHONY: test
 test: fmt vet ## Run unit tests.
-	go test ./internal/... -count=1 -coverprofile=coverage.out
+	go test ./internal/... -race -count=1 -coverprofile=coverage.out
 	@go tool cover -func=coverage.out | tail -1
 
 .PHONY: test-html

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -244,11 +244,11 @@ func main() {
 			setupLog.Error(nil, "keycloak-url is required when auth is enabled")
 			os.Exit(1)
 		}
-		jwtValidator, err = auth.NewJWTValidator(keycloakURL, keycloakRealm)
-		if err != nil {
-			setupLog.Error(err, "Failed to create JWT validator")
-			os.Exit(1)
-		}
+		// NewJWTValidator returns immediately; the initial JWKS fetch runs on
+		// a background goroutine. The HTTP server can therefore bind to its
+		// port and answer liveness probes even if Keycloak is still coming up.
+		// Handlers gating on Authorization return 503 until v.Ready() is true.
+		jwtValidator, _ = auth.NewJWTValidator(keycloakURL, keycloakRealm)
 		// KEYCLOAK_ISSUER_URL lets operators keep KEYCLOAK_URL pointing at the
 		// internal cluster address (fast, no TLS) while validating the `iss`
 		// claim against the external public URL that Keycloak embeds in tokens.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -248,7 +248,7 @@ func main() {
 		// a background goroutine. The HTTP server can therefore bind to its
 		// port and answer liveness probes even if Keycloak is still coming up.
 		// Handlers gating on Authorization return 503 until v.Ready() is true.
-		jwtValidator, _ = auth.NewJWTValidator(keycloakURL, keycloakRealm)
+		jwtValidator = auth.NewJWTValidator(keycloakURL, keycloakRealm)
 		// KEYCLOAK_ISSUER_URL lets operators keep KEYCLOAK_URL pointing at the
 		// internal cluster address (fast, no TLS) while validating the `iss`
 		// claim against the external public URL that Keycloak embeds in tokens.

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -1281,6 +1281,15 @@ func (h *Handler) requireAuth(w http.ResponseWriter, r *http.Request) (*auth.Cla
 		// so that pin operations still work in dev/test mode (all stored under "").
 		return &auth.Claims{PreferredUsername: "_anonymous"}, true
 	}
+	// If the caller presented credentials but our JWKS fetch hasn't completed
+	// yet, surface that as 503 with a Retry-After hint so clients distinguish
+	// "auth not online yet" from "your token is bad" (401). Without this they
+	// would mistakenly clear cached credentials and bounce users to login.
+	if r.Header.Get("Authorization") != "" && !h.jwtValidator.Ready() {
+		w.Header().Set("Retry-After", "5")
+		http.Error(w, "JWT validator not ready; Keycloak may still be initializing", http.StatusServiceUnavailable)
+		return nil, false
+	}
 	claims, ok := h.extractAndValidateJWT(r)
 	if !ok {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -429,7 +429,11 @@ func (h *Handler) handleGetServices(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	claims, authenticated := h.extractAndValidateJWT(r)
+	claims, authenticated, err := h.extractAndValidateJWT(r)
+	if errors.Is(err, auth.ErrNotReady) {
+		writeAuthWarmupResponse(w)
+		return
+	}
 	pinnedUIDs := h.callerPinnedUIDs(claims, authenticated)
 
 	allServices := h.cache.GetAll()
@@ -498,7 +502,11 @@ func (h *Handler) handleGetServiceByUID(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	claims, authenticated := h.extractAndValidateJWT(r)
+	claims, authenticated, err := h.extractAndValidateJWT(r)
+	if errors.Is(err, auth.ErrNotReady) {
+		writeAuthWarmupResponse(w)
+		return
+	}
 	if !h.canAccessService(service, authenticated, claims) {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 		return
@@ -1024,10 +1032,22 @@ func (h *Handler) handleHealth(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (h *Handler) extractAndValidateJWT(r *http.Request) (*auth.Claims, bool) {
+// extractAndValidateJWT returns the parsed claims for the request, a boolean
+// indicating whether validation succeeded, and an error.
+//
+// The error is non-nil only when the caller presented credentials but the JWT
+// validator's initial JWKS fetch has not yet completed (auth.ErrNotReady). All
+// other failure modes — missing header, malformed scheme, bad signature, wrong
+// issuer — return (nil, false, nil) so the caller can treat the request as
+// anonymous. Callers that gate behavior on auth (returning a 401/403/private
+// data) should check the error first and emit 503 + Retry-After via
+// writeAuthWarmupResponse so clients distinguish "auth offline" from "your
+// token is bad" (401) or "your stuff disappeared" (silent anonymous).
+func (h *Handler) extractAndValidateJWT(r *http.Request) (*auth.Claims, bool, error) {
 	// Test/debug hook: use the injected extractor when present.
 	if h.claimsExtractor != nil {
-		return h.claimsExtractor(r)
+		claims, ok := h.claimsExtractor(r)
+		return claims, ok, nil
 	}
 
 	if !h.enableAuth || h.jwtValidator == nil {
@@ -1036,7 +1056,7 @@ func (h *Handler) extractAndValidateJWT(r *http.Request) (*auth.Claims, bool) {
 				"enableAuth", h.enableAuth,
 				"validatorConfigured", h.jwtValidator != nil)
 		}
-		return nil, false
+		return nil, false, nil
 	}
 
 	authHeader := r.Header.Get("Authorization")
@@ -1044,25 +1064,30 @@ func (h *Handler) extractAndValidateJWT(r *http.Request) (*auth.Claims, bool) {
 		if h.debugMode {
 			log.Info("[debug] No Authorization header on request", "path", r.URL.Path)
 		}
-		return nil, false
+		return nil, false, nil
 	}
 
 	parts := strings.Split(authHeader, " ")
 	if len(parts) != 2 || parts[0] != "Bearer" {
 		log.Info("Invalid Authorization header format",
 			"scheme", parts[0], "path", r.URL.Path)
-		return nil, false
+		return nil, false, nil
 	}
 
 	tokenString := parts[1]
 
 	claims, err := h.jwtValidator.ValidateToken(tokenString)
 	if err != nil {
+		if errors.Is(err, auth.ErrNotReady) {
+			// Propagate so the caller can surface 503 rather than silently
+			// degrading the user to anonymous during the warmup window.
+			return nil, false, err
+		}
 		log.Info("JWT validation failed",
 			"error", err.Error(),
 			"path", r.URL.Path,
 			"hint", "check KEYCLOAK_ISSUER_URL matches the 'iss' claim in the token")
-		return nil, false
+		return nil, false, nil
 	}
 
 	if h.debugMode {
@@ -1071,7 +1096,16 @@ func (h *Handler) extractAndValidateJWT(r *http.Request) (*auth.Claims, bool) {
 			"groups", claims.Groups,
 			"issuer", claims.Issuer)
 	}
-	return claims, true
+	return claims, true, nil
+}
+
+// writeAuthWarmupResponse writes a 503 + Retry-After response for callers
+// that hit extractAndValidateJWT during the JWKS warmup window. The SPA reads
+// Retry-After to back off rather than clearing credentials and bouncing the
+// user to the login page.
+func writeAuthWarmupResponse(w http.ResponseWriter) {
+	w.Header().Set("Retry-After", "5")
+	http.Error(w, "JWT validator not ready; Keycloak may still be initializing", http.StatusServiceUnavailable)
 }
 
 func (h *Handler) canAccessService(service *cache.ServiceInfo, authenticated bool, claims *auth.Claims) bool {
@@ -1128,7 +1162,11 @@ func (h *Handler) handleCallerIdentity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	claims, authenticated := h.extractAndValidateJWT(r)
+	claims, authenticated, err := h.extractAndValidateJWT(r)
+	if errors.Is(err, auth.ErrNotReady) {
+		writeAuthWarmupResponse(w)
+		return
+	}
 
 	var resp CallerIdentityResponse
 	if authenticated {
@@ -1281,16 +1319,11 @@ func (h *Handler) requireAuth(w http.ResponseWriter, r *http.Request) (*auth.Cla
 		// so that pin operations still work in dev/test mode (all stored under "").
 		return &auth.Claims{PreferredUsername: "_anonymous"}, true
 	}
-	// If the caller presented credentials but our JWKS fetch hasn't completed
-	// yet, surface that as 503 with a Retry-After hint so clients distinguish
-	// "auth not online yet" from "your token is bad" (401). Without this they
-	// would mistakenly clear cached credentials and bounce users to login.
-	if r.Header.Get("Authorization") != "" && !h.jwtValidator.Ready() {
-		w.Header().Set("Retry-After", "5")
-		http.Error(w, "JWT validator not ready; Keycloak may still be initializing", http.StatusServiceUnavailable)
+	claims, ok, err := h.extractAndValidateJWT(r)
+	if errors.Is(err, auth.ErrNotReady) {
+		writeAuthWarmupResponse(w)
 		return nil, false
 	}
-	claims, ok := h.extractAndValidateJWT(r)
 	if !ok {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return nil, false
@@ -1363,8 +1396,10 @@ func (h *Handler) handleDebug(w http.ResponseWriter, r *http.Request) {
 	// When a claimsExtractor is configured (test / dev injection) or when the full
 	// JWT validator is available, extractAndValidateJWT already handles everything.
 	// For the debug response we also want to surface the validation *error* when
-	// the real validator is present, so we run the two paths in parallel.
-	claims, authenticated := h.extractAndValidateJWT(r)
+	// the real validator is present, so we run the two paths in parallel. The
+	// ErrNotReady signal is intentionally discarded — debug should still serve
+	// during warmup so operators can see the reason in ValidationError below.
+	claims, authenticated, _ := h.extractAndValidateJWT(r)
 
 	authInfo := DebugAuthInfo{
 		Enabled:             h.enableAuth,

--- a/internal/auth/jwt_validator.go
+++ b/internal/auth/jwt_validator.go
@@ -90,6 +90,9 @@ type JWTValidator struct {
 	// doneCh closes when initLoop exits (either on success, on stop, or
 	// before entering slow poll). Used by Stop() to wait for the goroutine.
 	doneCh chan struct{}
+	// stopOnce guards the close(stopCh) in Stop so concurrent callers cannot
+	// double-close the channel.
+	stopOnce sync.Once
 }
 
 // JWK represents a JSON Web Key
@@ -115,7 +118,7 @@ type JWKS struct {
 // exponential backoff. If those all fail, it switches to a `slowPollInterval`
 // cadence and keeps trying indefinitely. Either way, `Ready()` flips to true
 // the moment any fetch succeeds.
-func NewJWTValidator(keycloakURL, realm string) (*JWTValidator, error) {
+func NewJWTValidator(keycloakURL, realm string) *JWTValidator {
 	cleanURL := strings.TrimSuffix(keycloakURL, "/")
 	v := &JWTValidator{
 		keycloakURL: cleanURL,
@@ -130,7 +133,7 @@ func NewJWTValidator(keycloakURL, realm string) (*JWTValidator, error) {
 
 	log.Info("JWT validator created; initial JWKS fetch running in background",
 		"keycloakURL", keycloakURL, "realm", realm)
-	return v, nil
+	return v
 }
 
 // initLoop runs the initial JWKS fetch with exponential backoff, then falls
@@ -145,16 +148,16 @@ func (v *JWTValidator) initLoop() {
 		if v.stopped() {
 			return
 		}
-		if err := v.fetchPublicKeys(); err == nil {
+		err := v.fetchPublicKeys()
+		if err == nil {
 			v.ready.Store(true)
 			log.Info("JWT validator ready", "attempt", attempt)
 			return
-		} else {
-			log.Info("Failed to fetch Keycloak public keys, retrying",
-				"attempt", attempt, "maxRetries", retryMaxAttempts,
-				"backoff", backoff, "error", err,
-				"hint", "verify KEYCLOAK_URL is correct — Keycloak 17+ does not use /auth as a context root")
 		}
+		log.Info("Failed to fetch Keycloak public keys, retrying",
+			"attempt", attempt, "maxRetries", retryMaxAttempts,
+			"backoff", backoff, "error", err,
+			"hint", "verify KEYCLOAK_URL is correct — Keycloak 17+ does not use /auth as a context root")
 		if attempt < retryMaxAttempts {
 			retryDelay(backoff)
 			backoff *= 2
@@ -178,13 +181,13 @@ func (v *JWTValidator) initLoop() {
 			return
 		case <-time.After(slowPollInterval):
 		}
-		if err := v.fetchPublicKeys(); err == nil {
+		err := v.fetchPublicKeys()
+		if err == nil {
 			v.ready.Store(true)
 			log.Info("JWT validator ready (slow poll)")
 			return
-		} else {
-			log.Info("Slow poll JWKS fetch failed", "error", err)
 		}
+		log.Info("Slow poll JWKS fetch failed", "error", err)
 	}
 }
 
@@ -208,16 +211,12 @@ func (v *JWTValidator) Ready() bool {
 }
 
 // Stop signals the background init goroutine to exit and waits for it.
-// Safe to call multiple times. In production, NewJWTValidator's goroutine
-// runs for process lifetime so Stop is mainly for tests that need to avoid
-// leaking goroutines.
+// Safe to call multiple times, including concurrently from multiple goroutines
+// (stopOnce guards against a double-close panic). In production,
+// NewJWTValidator's goroutine runs for process lifetime so Stop is mainly for
+// tests that need to avoid leaking goroutines.
 func (v *JWTValidator) Stop() {
-	select {
-	case <-v.stopCh:
-		// already closed
-	default:
-		close(v.stopCh)
-	}
+	v.stopOnce.Do(func() { close(v.stopCh) })
 	<-v.doneCh
 }
 

--- a/internal/auth/jwt_validator.go
+++ b/internal/auth/jwt_validator.go
@@ -5,11 +5,13 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -18,15 +20,28 @@ import (
 
 var log = ctrl.Log.WithName("jwt-validator")
 
-// retryMaxAttempts and retryInitialBackoff control the JWKS fetch retry loop in
-// NewJWTValidator. They are package-level variables so tests can override them
-// without incurring real sleep time.
+// retryMaxAttempts and retryInitialBackoff control the *active* JWKS fetch
+// retry loop run on the background init goroutine. After this budget is
+// exhausted the goroutine switches to slowPollInterval to keep trying
+// indefinitely without the exponential blow-up. They are package-level
+// variables so tests can override them without incurring real sleep time.
 var (
 	retryMaxAttempts    = 5
 	retryInitialBackoff = 2 * time.Second
 	// retryDelay is called between attempts; replaced in tests to avoid sleeping.
 	retryDelay = time.Sleep
+	// slowPollInterval is the cadence for the post-retry "keep trying" loop.
+	// 30 s is short enough to converge quickly when Keycloak finishes coming up
+	// but long enough that an operator looking at logs sees a clear "still
+	// failing" cadence rather than a tight retry storm.
+	slowPollInterval = 30 * time.Second
 )
+
+// ErrNotReady is returned by ValidateToken when the validator's initial JWKS
+// fetch has not completed yet. Callers should treat this as transient and
+// surface a 503 Service Unavailable so clients distinguish "Keycloak not
+// reachable yet" from "your token is bad" (401).
+var ErrNotReady = errors.New("jwt validator: initial JWKS fetch not yet complete")
 
 // Claims represents the JWT claims we care about
 type Claims struct {
@@ -37,7 +52,22 @@ type Claims struct {
 	Groups            []string `json:"groups"`
 }
 
-// JWTValidator validates JWT tokens from Keycloak
+// JWTValidator validates JWT tokens from Keycloak.
+//
+// The initial JWKS fetch runs asynchronously in a background goroutine started
+// by NewJWTValidator so that process startup does not block on Keycloak being
+// reachable. This matters in two scenarios:
+//
+//  1. Pod startup races: kubelet's liveness probe kills the webapi pod if it
+//     does not bind to :8080 quickly enough. A synchronous retry loop here
+//     blocks the HTTP server from starting and produces CrashLoopBackOff when
+//     Keycloak is slow to become reachable.
+//  2. JWKS rotation failures: if a later refresh fails, the validator keeps
+//     serving with its existing keys rather than crashing the pod.
+//
+// While `ready` is false, ValidateToken returns ErrNotReady, which handlers
+// surface as 503 Service Unavailable to distinguish "auth not online yet"
+// from "your token is bad" (401).
 type JWTValidator struct {
 	keycloakURL string
 	// issuerURL is used to validate the `iss` claim. It defaults to keycloakURL
@@ -49,6 +79,17 @@ type JWTValidator struct {
 	publicKeys map[string]*rsa.PublicKey
 	keysMu     sync.RWMutex
 	lastFetch  time.Time
+	// ready flips to true once the first JWKS fetch succeeds. Reads must use
+	// atomic.Bool because the writer runs on the background init goroutine
+	// while readers run on every request-handling goroutine.
+	ready atomic.Bool
+	// stopCh is closed by Stop() to interrupt the slow-poll loop. The active
+	// retry path uses retryDelay (overrideable in tests) and does not need
+	// the channel — it always completes within retryMaxAttempts iterations.
+	stopCh chan struct{}
+	// doneCh closes when initLoop exits (either on success, on stop, or
+	// before entering slow poll). Used by Stop() to wait for the goroutine.
+	doneCh chan struct{}
 }
 
 // JWK represents a JSON Web Key
@@ -65,10 +106,15 @@ type JWKS struct {
 	Keys []JWK `json:"keys"`
 }
 
-// NewJWTValidator creates a new JWT validator.
-// It retries the initial JWKS fetch with exponential backoff so that transient
-// Keycloak unavailability (e.g. slow startup, rolling restarts) does not crash
-// the service. retryMaxAttempts attempts are made before returning an error.
+// NewJWTValidator creates a new JWT validator and returns immediately. The
+// initial JWKS fetch runs on a background goroutine so the caller (typically
+// process startup wiring up the HTTP server) does not block on Keycloak being
+// reachable. See JWTValidator's doc comment for why this matters.
+//
+// The background goroutine first runs `retryMaxAttempts` active attempts with
+// exponential backoff. If those all fail, it switches to a `slowPollInterval`
+// cadence and keeps trying indefinitely. Either way, `Ready()` flips to true
+// the moment any fetch succeeds.
 func NewJWTValidator(keycloakURL, realm string) (*JWTValidator, error) {
 	cleanURL := strings.TrimSuffix(keycloakURL, "/")
 	v := &JWTValidator{
@@ -76,30 +122,103 @@ func NewJWTValidator(keycloakURL, realm string) (*JWTValidator, error) {
 		issuerURL:   cleanURL, // default; override with SetIssuerURL if needed
 		realm:       realm,
 		publicKeys:  make(map[string]*rsa.PublicKey),
+		stopCh:      make(chan struct{}),
+		doneCh:      make(chan struct{}),
 	}
 
+	go v.initLoop()
+
+	log.Info("JWT validator created; initial JWKS fetch running in background",
+		"keycloakURL", keycloakURL, "realm", realm)
+	return v, nil
+}
+
+// initLoop runs the initial JWKS fetch with exponential backoff, then falls
+// back to a slow poll if all active attempts fail. It exits as soon as any
+// fetch succeeds (subsequent refreshes are driven on-demand by ValidateToken)
+// or when Stop() is called.
+func (v *JWTValidator) initLoop() {
+	defer close(v.doneCh)
+
 	backoff := retryInitialBackoff
-	var lastErr error
 	for attempt := 1; attempt <= retryMaxAttempts; attempt++ {
-		lastErr = v.fetchPublicKeys()
-		if lastErr == nil {
-			break
+		if v.stopped() {
+			return
 		}
-		log.Info("Failed to fetch Keycloak public keys, retrying",
-			"attempt", attempt, "maxRetries", retryMaxAttempts,
-			"backoff", backoff, "error", lastErr,
-			"hint", "verify KEYCLOAK_URL is correct — Keycloak 17+ does not use /auth as a context root")
+		if err := v.fetchPublicKeys(); err == nil {
+			v.ready.Store(true)
+			log.Info("JWT validator ready", "attempt", attempt)
+			return
+		} else {
+			log.Info("Failed to fetch Keycloak public keys, retrying",
+				"attempt", attempt, "maxRetries", retryMaxAttempts,
+				"backoff", backoff, "error", err,
+				"hint", "verify KEYCLOAK_URL is correct — Keycloak 17+ does not use /auth as a context root")
+		}
 		if attempt < retryMaxAttempts {
 			retryDelay(backoff)
 			backoff *= 2
 		}
 	}
-	if lastErr != nil {
-		return nil, fmt.Errorf("failed to fetch public keys after %d attempts: %w", retryMaxAttempts, lastErr)
-	}
 
-	log.Info("JWT validator initialized", "keycloakURL", keycloakURL, "realm", realm)
-	return v, nil
+	// Active budget exhausted. Switch to slow polling so an operator looking at
+	// logs sees a steady "still failing" cadence rather than a tight retry
+	// storm, but the validator still comes online if Keycloak eventually
+	// recovers (e.g. a long-running restart, a misconfigured KEYCLOAK_URL
+	// fixed in-place).
+	//
+	// The sleep is a real time.After rather than retryDelay so tests do not
+	// have to override it — a test that overrode retryDelay to a no-op would
+	// otherwise see this loop spin tight.
+	log.Info("active retry budget exhausted; switching to slow poll",
+		"interval", slowPollInterval)
+	for {
+		select {
+		case <-v.stopCh:
+			return
+		case <-time.After(slowPollInterval):
+		}
+		if err := v.fetchPublicKeys(); err == nil {
+			v.ready.Store(true)
+			log.Info("JWT validator ready (slow poll)")
+			return
+		} else {
+			log.Info("Slow poll JWKS fetch failed", "error", err)
+		}
+	}
+}
+
+// stopped reports whether Stop() has been called. Used as a fast exit check
+// at the top of each active retry iteration.
+func (v *JWTValidator) stopped() bool {
+	select {
+	case <-v.stopCh:
+		return true
+	default:
+		return false
+	}
+}
+
+// Ready reports whether the initial JWKS fetch has succeeded. Handlers gating
+// on Authorization headers should return 503 Service Unavailable while this
+// is false so clients can distinguish "auth not online yet" from "your token
+// is bad" (401).
+func (v *JWTValidator) Ready() bool {
+	return v.ready.Load()
+}
+
+// Stop signals the background init goroutine to exit and waits for it.
+// Safe to call multiple times. In production, NewJWTValidator's goroutine
+// runs for process lifetime so Stop is mainly for tests that need to avoid
+// leaking goroutines.
+func (v *JWTValidator) Stop() {
+	select {
+	case <-v.stopCh:
+		// already closed
+	default:
+		close(v.stopCh)
+	}
+	<-v.doneCh
 }
 
 // SetIssuerURL overrides the URL used to validate the token's `iss` claim.
@@ -128,8 +247,14 @@ func (v *JWTValidator) SetIssuerURL(url string) {
 // 5 minutes, so a 30s window does not materially weaken security).
 const clockLeeway = 30 * time.Second
 
-// ValidateToken validates a JWT token and returns the claims
+// ValidateToken validates a JWT token and returns the claims.
+// Returns ErrNotReady if the initial JWKS fetch has not yet completed; the
+// caller should surface this as 503 Service Unavailable.
 func (v *JWTValidator) ValidateToken(tokenString string) (*Claims, error) {
+	if !v.ready.Load() {
+		return nil, ErrNotReady
+	}
+
 	if time.Since(v.lastFetch) > time.Hour {
 		if err := v.fetchPublicKeys(); err != nil {
 			log.Error(err, "Failed to refresh public keys")

--- a/internal/auth/jwt_validator_test.go
+++ b/internal/auth/jwt_validator_test.go
@@ -8,10 +8,12 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -85,13 +87,47 @@ func signJWT(t *testing.T, key *rsa.PrivateKey, issuer string, exp time.Time, ex
 	return s
 }
 
+// newValidator returns a validator pointing at srv and blocks until its
+// background JWKS fetch has succeeded. Stop() is registered on cleanup so
+// the goroutine does not leak between tests.
 func newValidator(t *testing.T, srv *httptest.Server) *JWTValidator {
 	t.Helper()
 	v, err := NewJWTValidator(srv.URL, testRealm)
 	if err != nil {
 		t.Fatalf("NewJWTValidator: %v", err)
 	}
+	t.Cleanup(v.Stop)
+	waitReady(t, v, 2*time.Second)
 	return v
+}
+
+// waitReady polls v.Ready() until it returns true or the deadline expires.
+// Tests use this in lieu of synchronous error returns from the constructor.
+func waitReady(t *testing.T, v *JWTValidator, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if v.Ready() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("validator never became ready within %v", timeout)
+}
+
+// waitForCalls polls *calls until it reaches want or the deadline expires.
+// Used by tests that need to observe an exact retry-budget count before
+// asserting and stopping the validator.
+func waitForCalls(t *testing.T, calls *int, want int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if *calls >= want {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("expected at least %d calls within %v, got %d", want, timeout, *calls)
 }
 
 // --- parseRSAPublicKey ---
@@ -133,24 +169,39 @@ func TestParseRSAPublicKey_InvalidE(t *testing.T) {
 
 // --- NewJWTValidator ---
 
-func TestNewJWTValidator_InvalidURL_ReturnsError(t *testing.T) {
-	withNoBackoff(t, 1)
-	_, err := NewJWTValidator("http://127.0.0.1:1", "realm")
-	if err == nil {
-		t.Error("expected error connecting to invalid URL")
+// assertNotReady waits a brief window then asserts Ready() never flipped.
+// All retries in tests use withNoBackoff (no sleeps), so the active retry
+// budget completes in microseconds; a few ms is enough to observe failure.
+func assertNotReady(t *testing.T, v *JWTValidator, settle time.Duration) {
+	t.Helper()
+	time.Sleep(settle)
+	if v.Ready() {
+		t.Error("validator unexpectedly became ready")
 	}
 }
 
-func TestNewJWTValidator_EmptyKeys_ReturnsError(t *testing.T) {
+func TestNewJWTValidator_InvalidURL_StaysNotReady(t *testing.T) {
+	withNoBackoff(t, 1)
+	v, err := NewJWTValidator("http://127.0.0.1:1", "realm")
+	if err != nil {
+		t.Fatalf("NewJWTValidator should not return an error: %v", err)
+	}
+	t.Cleanup(v.Stop)
+	assertNotReady(t, v, 50*time.Millisecond)
+}
+
+func TestNewJWTValidator_EmptyKeys_StaysNotReady(t *testing.T) {
 	withNoBackoff(t, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{"keys": []interface{}{}})
 	}))
 	defer srv.Close()
-	_, err := NewJWTValidator(srv.URL, testRealm)
-	if err == nil {
-		t.Error("expected error when JWKS has no keys")
+	v, err := NewJWTValidator(srv.URL, testRealm)
+	if err != nil {
+		t.Fatalf("NewJWTValidator should not return an error: %v", err)
 	}
+	t.Cleanup(v.Stop)
+	assertNotReady(t, v, 50*time.Millisecond)
 }
 
 func TestNewJWTValidator_Success(t *testing.T) {
@@ -159,6 +210,9 @@ func TestNewJWTValidator_Success(t *testing.T) {
 	v := newValidator(t, srv)
 	if v == nil {
 		t.Fatal("expected non-nil validator")
+	}
+	if !v.Ready() {
+		t.Error("expected Ready() to be true after successful JWKS fetch")
 	}
 }
 
@@ -329,7 +383,7 @@ func withNoBackoff(t *testing.T, maxAttempts int) {
 	})
 }
 
-func TestNewJWTValidator_404_ReturnsError(t *testing.T) {
+func TestNewJWTValidator_404_StaysNotReady(t *testing.T) {
 	// Regression: KEYCLOAK_URL pointing to a wrong endpoint returns HTTP 404.
 	withNoBackoff(t, 1)
 
@@ -338,14 +392,16 @@ func TestNewJWTValidator_404_ReturnsError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := NewJWTValidator(srv.URL, testRealm)
-	if err == nil {
-		t.Fatal("expected error when server returns 404")
+	v, err := NewJWTValidator(srv.URL, testRealm)
+	if err != nil {
+		t.Fatalf("NewJWTValidator should not return an error: %v", err)
 	}
+	t.Cleanup(v.Stop)
+	assertNotReady(t, v, 50*time.Millisecond)
 }
 
 func TestNewJWTValidator_RetriesOnTransientFailure(t *testing.T) {
-	// First 2 requests fail with 503; the third succeeds — validator should be created.
+	// First 2 requests fail with 503; the third succeeds — Ready() should flip.
 	withNoBackoff(t, 5)
 
 	key := generateTestKey(t)
@@ -375,18 +431,20 @@ func TestNewJWTValidator_RetriesOnTransientFailure(t *testing.T) {
 
 	v, err := NewJWTValidator(srv.URL, testRealm)
 	if err != nil {
-		t.Fatalf("expected success after retries, got: %v", err)
+		t.Fatalf("NewJWTValidator: %v", err)
 	}
-	if v == nil {
-		t.Fatal("expected non-nil validator")
-	}
+	t.Cleanup(v.Stop)
+	waitReady(t, v, 2*time.Second)
 	if calls != 3 {
 		t.Errorf("expected 3 calls to JWKS endpoint, got %d", calls)
 	}
 }
 
-func TestNewJWTValidator_ExhaustsRetries_ReturnsError(t *testing.T) {
-	// Server always fails — after maxRetries attempts an error must be returned.
+func TestNewJWTValidator_ExhaustsRetries_StaysNotReady(t *testing.T) {
+	// Server always fails — after maxRetries attempts Ready() must remain false
+	// and the active retry budget must be honored (the goroutine then enters the
+	// slow-poll loop, which uses real time.After and so will not fire before the
+	// test calls Stop()).
 	const attempts = 3
 	withNoBackoff(t, attempts)
 
@@ -397,9 +455,18 @@ func TestNewJWTValidator_ExhaustsRetries_ReturnsError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := NewJWTValidator(srv.URL, testRealm)
-	if err == nil {
-		t.Fatal("expected error when all retries are exhausted")
+	v, err := NewJWTValidator(srv.URL, testRealm)
+	if err != nil {
+		t.Fatalf("NewJWTValidator: %v", err)
+	}
+	t.Cleanup(v.Stop)
+	waitForCalls(t, &calls, attempts, time.Second)
+	// give the goroutine a chance to enter slow-poll (which uses real
+	// time.After(slowPollInterval) — 30 s in production, so no extra fetches
+	// fire within this window).
+	time.Sleep(50 * time.Millisecond)
+	if v.Ready() {
+		t.Error("validator unexpectedly became ready")
 	}
 	if calls != attempts {
 		t.Errorf("expected exactly %d attempts, got %d", attempts, calls)
@@ -414,25 +481,64 @@ func TestNewJWTValidator_BackoffDoublesOnEachRetry(t *testing.T) {
 	retryInitialBackoff = initial
 
 	var delays []time.Duration
-	retryDelay = func(d time.Duration) { delays = append(delays, d) }
+	var delaysMu sync.Mutex
+	retryDelay = func(d time.Duration) {
+		delaysMu.Lock()
+		delays = append(delays, d)
+		delaysMu.Unlock()
+	}
 
 	// Server always fails so we exercise all retry gaps.
+	calls := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
 		http.Error(w, "fail", http.StatusServiceUnavailable)
 	}))
 	defer srv.Close()
 
-	_, _ = NewJWTValidator(srv.URL, testRealm)
+	v, _ := NewJWTValidator(srv.URL, testRealm)
+	t.Cleanup(v.Stop)
+	waitForCalls(t, &calls, 4, time.Second)
+	// Give the goroutine a beat to record the final inter-attempt delay.
+	time.Sleep(20 * time.Millisecond)
+
+	delaysMu.Lock()
+	got := append([]time.Duration(nil), delays...)
+	delaysMu.Unlock()
 
 	// With 4 attempts there are 3 inter-attempt delays.
-	if len(delays) != 3 {
-		t.Fatalf("expected 3 delays, got %d: %v", len(delays), delays)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 delays, got %d: %v", len(got), got)
 	}
 	expected := []time.Duration{initial, initial * 2, initial * 4}
-	for i, d := range delays {
+	for i, d := range got {
 		if d != expected[i] {
 			t.Errorf("delay[%d]: got %v, want %v", i, d, expected[i])
 		}
+	}
+}
+
+func TestValidateToken_NotReady_ReturnsErrNotReady(t *testing.T) {
+	// Server hangs so the goroutine is stuck on the first attempt and Ready()
+	// stays false; ValidateToken must return ErrNotReady rather than a generic
+	// validation failure so handlers can surface 503 instead of 401.
+	withNoBackoff(t, 1)
+
+	block := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block
+	}))
+	defer func() { close(block); srv.Close() }()
+
+	v, err := NewJWTValidator(srv.URL, testRealm)
+	if err != nil {
+		t.Fatalf("NewJWTValidator: %v", err)
+	}
+	t.Cleanup(v.Stop)
+
+	_, err = v.ValidateToken("any-token")
+	if !errors.Is(err, ErrNotReady) {
+		t.Errorf("expected ErrNotReady, got %v", err)
 	}
 }
 

--- a/internal/auth/jwt_validator_test.go
+++ b/internal/auth/jwt_validator_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -92,10 +93,7 @@ func signJWT(t *testing.T, key *rsa.PrivateKey, issuer string, exp time.Time, ex
 // the goroutine does not leak between tests.
 func newValidator(t *testing.T, srv *httptest.Server) *JWTValidator {
 	t.Helper()
-	v, err := NewJWTValidator(srv.URL, testRealm)
-	if err != nil {
-		t.Fatalf("NewJWTValidator: %v", err)
-	}
+	v := NewJWTValidator(srv.URL, testRealm)
 	t.Cleanup(v.Stop)
 	waitReady(t, v, 2*time.Second)
 	return v
@@ -115,19 +113,20 @@ func waitReady(t *testing.T, v *JWTValidator, timeout time.Duration) {
 	t.Fatalf("validator never became ready within %v", timeout)
 }
 
-// waitForCalls polls *calls until it reaches want or the deadline expires.
+// waitForCalls polls calls until it reaches want or the deadline expires.
 // Used by tests that need to observe an exact retry-budget count before
-// asserting and stopping the validator.
-func waitForCalls(t *testing.T, calls *int, want int, timeout time.Duration) {
+// asserting and stopping the validator. The counter is atomic because the
+// HTTP handler goroutine and the test goroutine both touch it.
+func waitForCalls(t *testing.T, calls *atomic.Int32, want int32, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		if *calls >= want {
+		if calls.Load() >= want {
 			return
 		}
 		time.Sleep(2 * time.Millisecond)
 	}
-	t.Fatalf("expected at least %d calls within %v, got %d", want, timeout, *calls)
+	t.Fatalf("expected at least %d calls within %v, got %d", want, timeout, calls.Load())
 }
 
 // --- parseRSAPublicKey ---
@@ -182,10 +181,7 @@ func assertNotReady(t *testing.T, v *JWTValidator, settle time.Duration) {
 
 func TestNewJWTValidator_InvalidURL_StaysNotReady(t *testing.T) {
 	withNoBackoff(t, 1)
-	v, err := NewJWTValidator("http://127.0.0.1:1", "realm")
-	if err != nil {
-		t.Fatalf("NewJWTValidator should not return an error: %v", err)
-	}
+	v := NewJWTValidator("http://127.0.0.1:1", "realm")
 	t.Cleanup(v.Stop)
 	assertNotReady(t, v, 50*time.Millisecond)
 }
@@ -196,10 +192,7 @@ func TestNewJWTValidator_EmptyKeys_StaysNotReady(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{"keys": []interface{}{}})
 	}))
 	defer srv.Close()
-	v, err := NewJWTValidator(srv.URL, testRealm)
-	if err != nil {
-		t.Fatalf("NewJWTValidator should not return an error: %v", err)
-	}
+	v := NewJWTValidator(srv.URL, testRealm)
 	t.Cleanup(v.Stop)
 	assertNotReady(t, v, 50*time.Millisecond)
 }
@@ -392,10 +385,7 @@ func TestNewJWTValidator_404_StaysNotReady(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	v, err := NewJWTValidator(srv.URL, testRealm)
-	if err != nil {
-		t.Fatalf("NewJWTValidator should not return an error: %v", err)
-	}
+	v := NewJWTValidator(srv.URL, testRealm)
 	t.Cleanup(v.Stop)
 	assertNotReady(t, v, 50*time.Millisecond)
 }
@@ -405,7 +395,7 @@ func TestNewJWTValidator_RetriesOnTransientFailure(t *testing.T) {
 	withNoBackoff(t, 5)
 
 	key := generateTestKey(t)
-	calls := 0
+	var calls atomic.Int32
 	jwks := map[string]interface{}{
 		"keys": []map[string]interface{}{
 			{
@@ -419,8 +409,8 @@ func TestNewJWTValidator_RetriesOnTransientFailure(t *testing.T) {
 	}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls++
-		if calls <= 2 {
+		n := calls.Add(1)
+		if n <= 2 {
 			http.Error(w, "service unavailable", http.StatusServiceUnavailable)
 			return
 		}
@@ -429,14 +419,11 @@ func TestNewJWTValidator_RetriesOnTransientFailure(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	v, err := NewJWTValidator(srv.URL, testRealm)
-	if err != nil {
-		t.Fatalf("NewJWTValidator: %v", err)
-	}
+	v := NewJWTValidator(srv.URL, testRealm)
 	t.Cleanup(v.Stop)
 	waitReady(t, v, 2*time.Second)
-	if calls != 3 {
-		t.Errorf("expected 3 calls to JWKS endpoint, got %d", calls)
+	if got := calls.Load(); got != 3 {
+		t.Errorf("expected 3 calls to JWKS endpoint, got %d", got)
 	}
 }
 
@@ -445,20 +432,17 @@ func TestNewJWTValidator_ExhaustsRetries_StaysNotReady(t *testing.T) {
 	// and the active retry budget must be honored (the goroutine then enters the
 	// slow-poll loop, which uses real time.After and so will not fire before the
 	// test calls Stop()).
-	const attempts = 3
-	withNoBackoff(t, attempts)
+	const attempts int32 = 3
+	withNoBackoff(t, int(attempts))
 
-	calls := 0
+	var calls atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls++
+		calls.Add(1)
 		http.Error(w, "internal error", http.StatusInternalServerError)
 	}))
 	defer srv.Close()
 
-	v, err := NewJWTValidator(srv.URL, testRealm)
-	if err != nil {
-		t.Fatalf("NewJWTValidator: %v", err)
-	}
+	v := NewJWTValidator(srv.URL, testRealm)
 	t.Cleanup(v.Stop)
 	waitForCalls(t, &calls, attempts, time.Second)
 	// give the goroutine a chance to enter slow-poll (which uses real
@@ -468,8 +452,8 @@ func TestNewJWTValidator_ExhaustsRetries_StaysNotReady(t *testing.T) {
 	if v.Ready() {
 		t.Error("validator unexpectedly became ready")
 	}
-	if calls != attempts {
-		t.Errorf("expected exactly %d attempts, got %d", attempts, calls)
+	if got := calls.Load(); got != attempts {
+		t.Errorf("expected exactly %d attempts, got %d", attempts, got)
 	}
 }
 
@@ -489,14 +473,14 @@ func TestNewJWTValidator_BackoffDoublesOnEachRetry(t *testing.T) {
 	}
 
 	// Server always fails so we exercise all retry gaps.
-	calls := 0
+	var calls atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		calls++
+		calls.Add(1)
 		http.Error(w, "fail", http.StatusServiceUnavailable)
 	}))
 	defer srv.Close()
 
-	v, _ := NewJWTValidator(srv.URL, testRealm)
+	v := NewJWTValidator(srv.URL, testRealm)
 	t.Cleanup(v.Stop)
 	waitForCalls(t, &calls, 4, time.Second)
 	// Give the goroutine a beat to record the final inter-attempt delay.
@@ -530,13 +514,10 @@ func TestValidateToken_NotReady_ReturnsErrNotReady(t *testing.T) {
 	}))
 	defer func() { close(block); srv.Close() }()
 
-	v, err := NewJWTValidator(srv.URL, testRealm)
-	if err != nil {
-		t.Fatalf("NewJWTValidator: %v", err)
-	}
+	v := NewJWTValidator(srv.URL, testRealm)
 	t.Cleanup(v.Stop)
 
-	_, err = v.ValidateToken("any-token")
+	_, err := v.ValidateToken("any-token")
 	if !errors.Is(err, ErrNotReady) {
 		t.Errorf("expected ErrNotReady, got %v", err)
 	}


### PR DESCRIPTION
## Summary

- `NewJWTValidator` now returns immediately and runs the initial JWKS fetch on a background goroutine. The HTTP server binds to `:8080` and answers the liveness probe even while Keycloak is still warming up.
- `ValidateToken` returns `ErrNotReady` until the first fetch succeeds. `requireAuth` surfaces this as **503 Service Unavailable + `Retry-After: 5`** when an `Authorization` header is present, so clients can tell "auth not online yet" from 401 ("your token is bad") and the SPA does not clear cached credentials.
- After the active retry budget is exhausted, the goroutine switches to a 30 s slow-poll loop, so a later Keycloak outage or a delayed cold start no longer wedges the pod into CrashLoopBackOff — Ready() flips the moment Keycloak comes back.

Closes #85.

## Why

Repro on `main`: `make -f dev/Makefile setup` with a slow Keycloak cold-start. The webapi log loops with:

```
INFO jwt-validator Failed to fetch Keycloak public keys, retrying  {"attempt": N/5, "error": "context deadline exceeded"}
```

…and the pod hits `CrashLoopBackOff` because the synchronous retry loop blocks the HTTP server from starting; kubelet's liveness probe (`initialDelaySeconds:10`, `periodSeconds:30`, `failureThreshold:3`) sees `connection refused` at `:8080/api/v1/health` and kills the pod at ~+70 s — before the 5-attempt retry budget (up to ~62 s of backoff plus per-attempt 10 s HTTP timeouts) can complete.

The fix decouples the two: process startup wires up the HTTP server unconditionally; auth-gated handlers serve 503 until the validator is ready. This was Option 1 from my issue comment.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all packages pass
- [x] New `TestValidateToken_NotReady_ReturnsErrNotReady` covers the 503 path
- [x] Constructor-error tests rewritten to assert `Ready()` stays false within a bounded window
- [x] `Stop()` registered on `t.Cleanup` so the background goroutine does not leak across tests
- [x] Manual: deploy this branch onto the reproducer cluster and confirm webapi pod no longer crashloops while Keycloak is starting (requested by issue reporter)