### PR TITLE
fix(dev): align keycloak Service port with NIC (closes #88)

### DIFF
--- a/dev/Makefile
+++ b/dev/Makefile
@@ -671,7 +671,7 @@ port-forward:
 	@echo "→  (Re)starting port-forwards in the background …"
 	@pkill -f "kubect[l].*port-forward.*keycloak-keycloakx-http" 2>/dev/null || true
 	@pkill -f "kubect[l].*port-forward.*(nebari-landing-webapi|nebari-landing-frontend)" 2>/dev/null || true
-	@nohup $(KUBECTL_BIN) -n $(NAMESPACE_KC)  port-forward svc/keycloak-keycloakx-http        $(PORT_KEYCLOAK):80   > /tmp/pf-keycloak.log 2>&1 &
+	@nohup $(KUBECTL_BIN) -n $(NAMESPACE_KC)  port-forward svc/keycloak-keycloakx-http        $(PORT_KEYCLOAK):8080 > /tmp/pf-keycloak.log 2>&1 &
 	@nohup $(KUBECTL_BIN) -n $(NAMESPACE_APP) port-forward svc/$(HELM_RELEASE)-webapi          $(PORT_WEBAPI):8080  > /tmp/pf-webapi.log 2>&1 &
 	@nohup $(KUBECTL_BIN) -n $(NAMESPACE_APP) port-forward svc/$(HELM_RELEASE)-frontend        $(PORT_LANDING):8080 > /tmp/pf-landing.log 2>&1 &
 	@sleep 2

--- a/dev/keycloak/frontend-client-job.yaml
+++ b/dev/keycloak/frontend-client-job.yaml
@@ -37,7 +37,8 @@ spec:
                   name: keycloak-admin-credentials
                   key: admin-password
             - name: KEYCLOAK_URL
-              value: http://keycloak-keycloakx-http.keycloak.svc.cluster.local
+              # Service exposes :8080 (matches NIC's keycloakx chart values)
+              value: http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080
             # Static dev secret for the confidential oauth2-proxy client.
             # Safe only for local minikube; the operator generates a random one in prod.
             - name: CLIENT_SECRET

--- a/dev/keycloak/realm-setup-job.yaml
+++ b/dev/keycloak/realm-setup-job.yaml
@@ -25,7 +25,8 @@ spec:
                   name: nebari-realm-admin-credentials
                   key: password
             - name: KEYCLOAK_URL
-              value: http://keycloak-keycloakx-http.keycloak.svc.cluster.local
+              # Service exposes :8080 (matches NIC's keycloakx chart values)
+              value: http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080
           command:
             - /bin/bash
             - -c

--- a/dev/keycloak/values.yaml
+++ b/dev/keycloak/values.yaml
@@ -86,9 +86,16 @@ startupProbe: |
   failureThreshold: 60
 
 service:
-  # MetalLB LoadBalancer — pinned to 192.168.49.100, exposed on port 80
+  # MetalLB LoadBalancer — pinned to 192.168.49.100. Service port matches the
+  # pod's targetPort (8080) so the in-cluster URL the webapi uses
+  # (http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080) resolves
+  # identically to what NIC's keycloakx chart values produce in production. See
+  # nebari-infrastructure-core/pkg/argocd/templates/apps/keycloak.yaml — same
+  # service.httpPort: 8080 there. End-user browser access still goes through
+  # the localhost:8180 port-forward set up by `make port-forward`, so the
+  # external-port change is invisible to anyone following dev/QUICKSTART.md.
   type: LoadBalancer
-  httpPort: 80
+  httpPort: 8080
   loadBalancerIP: "192.168.49.100"
 
 ingress:

--- a/dev/keycloak/webapi-client-job.yaml
+++ b/dev/keycloak/webapi-client-job.yaml
@@ -21,7 +21,8 @@ spec:
                   name: keycloak-admin-credentials
                   key: admin-password
             - name: KEYCLOAK_URL
-              value: http://keycloak-keycloakx-http.keycloak.svc.cluster.local
+              # Service exposes :8080 (matches NIC's keycloakx chart values)
+              value: http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080
           command:
             - /bin/bash
             - -c

--- a/dev/webapi_test.py
+++ b/dev/webapi_test.py
@@ -20,7 +20,7 @@ Prerequisites:
     pip install requests
 
 Port-forwards (run in separate terminals before this script):
-    kubectl -n keycloak      port-forward svc/keycloak-keycloakx-http 8180:80
+    kubectl -n keycloak      port-forward svc/keycloak-keycloakx-http 8180:8080
     kubectl -n nebari-system port-forward svc/nebari-landing-webapi   8090:8080
 
 Also apply test NebariApps:


### PR DESCRIPTION
Closes #88.

## Why

The webapi config in `dev/chart-values.yaml` points at
`http://keycloak-keycloakx-http.keycloak.svc.cluster.local:8080` — same URL NIC's nebari-landingpage Argo app uses in production. Dev's chart values had `service.httpPort: 80`, so the webapi was hitting a Service port that doesn't exist. Connection timeout → synchronous JWKS retry exhausts → `CrashLoopBackOff`.

NIC's `keycloak` Argo app values set `service.httpPort: 8080` ([`pkg/argocd/templates/apps/keycloak.yaml`](https://github.com/nebari-dev/nebari-infrastructure-core/blob/main/pkg/argocd/templates/apps/keycloak.yaml)). Dev should mirror that so the in-cluster URL works identically in both paths.

The dev path has been broken since [PR #55](https://github.com/nebari-dev/nebari-landing/pull/55) added the `:8080` URL to `dev/chart-values.yaml` without the matching chart value change. The bug surfaced sharply once @karamba228 hit it on a fresh `make setup` and reported it as #88.

## What changes

- `dev/keycloak/values.yaml`: `service.httpPort: 80` → `service.httpPort: 8080`. Comment rewritten to explain the alignment with NIC and to call out that browser access still goes through the `localhost:8180` port-forward.
- `dev/Makefile` port-forward target: `$(PORT_KEYCLOAK):80` → `$(PORT_KEYCLOAK):8080`.
- `dev/keycloak/{realm-setup,frontend-client,webapi-client}-job.yaml`: kcadm Jobs hit `…:8080` explicitly (was no-port = implicit 80).
- `dev/webapi_test.py`: port-forward example in the docstring updated.

The dev path stays compatible at the user-visible layer:
- `make port-forward` still exposes Keycloak at `http://localhost:8180`.
- `KC_HOSTNAME_URL` is unchanged (still `http://localhost:8180`, set by `make keycloak-install` via `envsubst`).
- The MetalLB external IP for Keycloak (192.168.49.100) is no longer in active use by any `make` target — the dev path routes via port-forward — so the external port change is invisible to the documented `dev/QUICKSTART.md` flow.

## Verification

End-to-end on the live `nebari-local` cluster I reproduced #88 on:

1. `helm upgrade keycloak codecentric/keycloakx … -f dev/keycloak/values.yaml` → Service now exposes `http: 8080 → http`.
2. `kubectl set env deploy/nebari-landing-webapi KEYCLOAK_URL=…:8080` (the value the chart already produces).
3. Webapi pod transitions to **`Running 1/1`, 0 restarts** (was `CrashLoopBackOff` after 3,741 restarts).
4. Log: `Keycloak admin client configured … :8080` followed by `Starting HTTP server` and the watcher discovering all four test NebariApp CRs.

## Out of scope

- `dev/QUICKSTART.md`'s stale oauth2-proxy references and direct MetalLB-IP browser URLs are tracked in #94; not touched here.
- The `helm/chart-releaser` migration discussed alongside this issue is a separate follow-up.