### PR TITLE
card sizing fix

### DIFF
--- a/frontend/src/components/ServiceGridCard.tsx
+++ b/frontend/src/components/ServiceGridCard.tsx
@@ -29,9 +29,12 @@ export function ServiceGridCard({
             <StatusBadge status={service.status} />
           </div>
 
-          <div className="mt-4 block">
+          <div className="mt-4 min-h-0">
             <p className="text-base font-bold text-foreground">{service.name}</p>
-            <p className="mt-1 text-sm text-muted-foreground">
+            <p
+              className="mt-1 line-clamp-2 text-sm text-muted-foreground"
+              title={service.description}
+            >
               {service.description}
             </p>
           </div>

--- a/frontend/src/components/ServiceGridCard.tsx
+++ b/frontend/src/components/ServiceGridCard.tsx
@@ -19,10 +19,10 @@ export function ServiceGridCard({
       href={service.url}
       target="_blank"
       rel="noreferrer"
-      className="block overflow-visible focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+      className="block h-56 overflow-visible focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
     >
-      <Card className="overflow-hidden border border-border bg-background shadow-none transition-none hover:bg-black/[0.02] dark:hover:bg-white/[0.03]">
-        <CardContent className="p-4">
+      <Card className="h-full overflow-hidden border border-border bg-background shadow-none transition-none hover:bg-black/[0.02] dark:hover:bg-white/[0.03]">
+        <CardContent className="flex h-full flex-col p-4 pb-2">
           <div className="flex items-start justify-between gap-3">
             <ServiceIcon imageUrl={service.image} />
 
@@ -36,10 +36,10 @@ export function ServiceGridCard({
             </p>
           </div>
 
-          <div className="my-4 border-t" />
+          <div className="mb-2 mt-auto border-t" />
 
           <div className="flex items-center justify-between gap-3">
-            <div className="flex flex-wrap gap-2">
+            <div className="flex min-w-0 flex-wrap gap-2 overflow-hidden">
               {service.category.map((item) => (
                 <span
                   key={item}


### PR DESCRIPTION
### In the PR
- Fix for the card sizing mismatch on screen resize

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
