### PR TITLE
feat(chart): expose httpRoute.tlsSecretName for pre-provisioned TLS secrets

### DIFF
--- a/charts/nebari-landing/templates/nebariapp.yaml
+++ b/charts/nebari-landing/templates/nebariapp.yaml
@@ -26,6 +26,9 @@ spec:
         pathType: PathPrefix
     tls:
       enabled: {{ .Values.httpRoute.tls }}
+      {{- with .Values.httpRoute.tlsSecretName }}
+      secretName: {{ . | quote }}
+      {{- end }}
 
   # Auth is enforced in-process by keycloak-js (PKCE) in the browser and by the
   # webapi's JWT validator. No gateway SecurityPolicy is needed.

--- a/charts/nebari-landing/values.yaml
+++ b/charts/nebari-landing/values.yaml
@@ -215,6 +215,13 @@ httpRoute:
   # TLS is terminated by the Gateway; set to true when the Gateway listener
   # uses HTTPS so the route is only matched on the TLS listener.
   tls: true
+  # Name of a pre-provisioned TLS Secret in the gateway namespace to terminate
+  # TLS with. When set, the operator uses this Secret instead of issuing a
+  # cert through cert-manager — point this at an enterprise-CA-signed wildcard
+  # cert on clusters where the cert-manager selfsigned-issuer flow yields a
+  # browser-untrusted cert. Leave empty to keep the cert-manager behaviour.
+  # Requires nebari-operator >= v0.1.0-alpha.20 (routing.tls.secretName support).
+  tlsSecretName: ""
 
 # ---------------------------------------------------------------------------
 # Redis subchart (bitnami/redis 23.1.1)


### PR DESCRIPTION
## Summary

Closes #101.

The `NebariApp` template (`charts/nebari-landing/templates/nebariapp.yaml`) only emitted `routing.tls.enabled`, and `values.yaml` exposed no `secretName` under `httpRoute`. So on a cluster that already has a pre-provisioned wildcard TLS secret (e.g. an enterprise-CA-signed cert in the gateway namespace), there was no values path to point the landing page at it — the operator fell back to its cert-manager flow, which on a `selfsigned-issuer` cluster yields a browser-untrusted cert or wedges the `Certificate` in `SecretMismatch`.

The operator has supported `spec.routing.tls.secretName` since `v0.1.0-alpha.20` (nebari-dev/nebari-operator#114), already in use by NIC — the chart just didn't surface it.

## What changes

This is **option 2** from the issue — the surgical, non-breaking fix. An optional `httpRoute.tlsSecretName` value, emitted under `routing.tls` only when set:

```diff
     tls:
       enabled: {{ .Values.httpRoute.tls }}
+      {{- with .Values.httpRoute.tlsSecretName }}
+      secretName: {{ . | quote }}
+      {{- end }}
```

plus the documented value in `values.yaml` (defaults to `""`).

I deliberately did **not** take option 1 (full `toYaml` passthrough on the routing block). Unlike the sibling data-science-pack chart — whose template is a thin passthrough — this chart hand-renders an opinionated `NebariApp` spec (keycloak protocol mappers, `spaClient` PKCE config) and sources routing from a separate `httpRoute.*` values shape. A true passthrough would mean restructuring `httpRoute.*` → `nebariApp.routing.*`, a breaking values change, for no benefit to this specific fix.

## Verification

`helm template` with `nebariApp.enabled=true`:

- **`tlsSecretName` unset (default):** routing block renders byte-for-byte identical to before — `routing.tls` carries only `enabled`. Existing deployments unaffected.
- **`tlsSecretName: my-wildcard-tls`:** renders `secretName: "my-wildcard-tls"` under `routing.tls`, landing in `NebariApp.spec.routing.tls.secretName`.

`helm lint` passes.

## Acceptance criteria (from #101)

- [x] Setting a `secretName` value renders into `NebariApp.spec.routing.tls.secretName`.
- [x] When unset, behavior is unchanged from today.
- [x] Documented in `values.yaml`, pointing at the enterprise-CA / pre-provisioned-secret use case.

## Related

- Operator support: nebari-dev/nebari-operator#114 (`routing.tls.secretName`, released `v0.1.0-alpha.20`)
- Same drift class, sibling chart: nebari-dev/nebari-data-science-pack#94 extends `toYaml` passthrough to `auth`/`landingPage`. The broader "every pack re-implements `nebariapp.yaml` and drifts from the CRD" problem is being tracked there as a library-chart proposal; this PR is the local fix for the landing chart's routing gap.