### PR TITLE
Add configurable top and bottom banners to branding config

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Release artifacts — the Go webapi binary (linux/darwin, amd64/arm64) and the p
 | **SSO-Aware** | keycloak-js PKCE in the browser, JWT validation by the webapi — users land authenticated, admins see admin controls |
 | **Pins & Access Requests** | Users can pin favourite services and request access to restricted ones |
 | **shadcn/ui + Tailwind** | Accessible UI primitives with theme tokens; no design-system runtime to ship |
-| **Runtime Branding** | Custom title, logo, favicon, and CSS theme tokens — no image rebuild required |
+| **Runtime Branding** | Custom title, logo, favicon, CSS theme tokens, and classification banners — no image rebuild required |
 
 ## Branding & Theming
 
@@ -123,6 +123,8 @@ settings to the document before React mounts. No image rebuild is needed — cha
 | `frontend.branding.faviconUrl` | string | URL to a custom favicon |
 | `frontend.branding.theme.light` | map | CSS variable overrides for light mode |
 | `frontend.branding.theme.dark` | map | CSS variable overrides for dark mode |
+| `frontend.branding.banners.top` | map | Classification banner pinned above the header (see below) |
+| `frontend.branding.banners.bottom` | map | Classification banner pinned below the page content (see below) |
 
 ### Supported theme tokens
 
@@ -132,6 +134,36 @@ The `theme.light` and `theme.dark` maps accept any combination of these token na
 
 Each token maps to a CSS custom property on `:root` (light) or `.dark` (dark). For example, `primary: "#0066cc"`
 becomes `--primary: #0066cc;`.
+
+### Classification banners
+
+Deployments in regulated or government environments often require a persistent classification banner (e.g.
+[CUI](https://www.archives.gov/cui)) pinned to the top and bottom of every page. The `banners.top` and
+`banners.bottom` maps each accept:
+
+| Key | Type | Description |
+| --- | --- | --- |
+| `text` | string | Banner text, rendered as plain text (HTML is never interpreted). A banner is disabled while its `text` is empty — the default — so standard deployments show no banner and no layout shift |
+| `background` | string | Optional CSS background color. Defaults to the theme foreground color, which follows light/dark mode |
+| `foreground` | string | Optional CSS text color. Defaults to the theme background color, which follows light/dark mode |
+
+```yaml
+frontend:
+  branding:
+    banners:
+      top:
+        text: "CUI"
+        background: "#502b85"
+        foreground: "#ffffff"
+      bottom:
+        text: "CUI"
+        background: "#502b85"
+        foreground: "#ffffff"
+```
+
+The exact text and colors mandated for your environment are policy-specific — this chart provides the mechanism;
+operators supply values per their compliance requirements. Banners are deployment-global (the same on every page)
+and non-interactive.
 
 ### Example
 
@@ -152,8 +184,8 @@ frontend:
         primaryForeground: "#000000"
 ```
 
-> **Security note:** Token values are validated at runtime. Values containing CSS injection vectors (`;`, `{`, `}`,
-> `url()`, `expression()`, `javascript:`, etc.) are silently dropped.
+> **Security note:** Theme token and banner color values are validated at runtime. Values containing CSS injection
+> vectors (`;`, `{`, `}`, `url()`, `expression()`, `javascript:`, etc.) are silently dropped.
 
 ## Helm Install
 

--- a/charts/nebari-landing/templates/frontend/configmap.yaml
+++ b/charts/nebari-landing/templates/frontend/configmap.yaml
@@ -21,7 +21,8 @@ data:
       "logoUrl":   {{ .Values.frontend.branding.logoUrl   | quote }},
       "logoUrlDark": {{ .Values.frontend.branding.logoUrlDark | quote }},
       "faviconUrl": {{ .Values.frontend.branding.faviconUrl | quote }},
-      "theme":      {{ .Values.frontend.branding.theme | toJson }}
+      "theme":      {{ .Values.frontend.branding.theme | toJson }},
+      "banners":    {{ .Values.frontend.branding.banners | toJson }}
     }
 
   # nginx configuration for the frontend pod.

--- a/charts/nebari-landing/values.yaml
+++ b/charts/nebari-landing/values.yaml
@@ -73,6 +73,23 @@ frontend:
     theme:
       light: {}
       dark: {}
+    # Optional classification banners (e.g. U.S. government CUI markings)
+    # rendered full-width above the header (top) and below the page content
+    # (bottom). Rendered into /config.json at runtime — no image rebuild.
+    # A banner is disabled while its text is empty. background/foreground
+    # accept CSS color values; when omitted the banner uses the theme's
+    # inverted colors, which follow light/dark mode.
+    # Example:
+    #   banners:
+    #     top:
+    #       text: "CUI"
+    #       background: "#502b85"
+    #       foreground: "#ffffff"
+    #     bottom:
+    #       text: "CUI"
+    banners:
+      top: {}
+      bottom: {}
 
   resources:
     requests:

--- a/frontend/public/config.json
+++ b/frontend/public/config.json
@@ -7,5 +7,9 @@
   "title": "",
   "logoUrl": "",
   "logoUrlDark": "",
-  "faviconUrl": ""
+  "faviconUrl": "",
+  "banners": {
+    "top": {},
+    "bottom": {}
+  }
 }

--- a/frontend/src/app/config.ts
+++ b/frontend/src/app/config.ts
@@ -21,6 +21,15 @@ export type ThemeTokens = {
   radius?: string;
 };
 
+export type BannerConfig = {
+  /** Banner text, rendered as plain text (never HTML). */
+  text: string;
+  /** Optional CSS background color. Falls back to the theme foreground color. */
+  background?: string;
+  /** Optional CSS text color. Falls back to the theme background color. */
+  foreground?: string;
+};
+
 export type AppConfig = {
   keycloak: { url: string; realm: string; clientId: string };
   /** Optional page title override shown in the browser tab. */
@@ -36,6 +45,11 @@ export type AppConfig = {
   faviconUrl?: string;
   /** Optional CSS variable overrides for light and dark mode. */
   theme?: { light?: ThemeTokens; dark?: ThemeTokens };
+  /**
+   * Optional classification banners (e.g. CUI) pinned above the header and
+   * below the page content.
+   */
+  banners?: { top?: BannerConfig; bottom?: BannerConfig };
 };
 
 let _config: AppConfig | null = null;
@@ -76,6 +90,11 @@ export function getAppConfig(): AppConfig | null {
 
 // Block CSS injection vectors: rule terminators, braces, HTML chars, url()/expression()/javascript:
 const UNSAFE_CSS = /[;<>{}"'\\]|url\s*\(|expression\s*\(|javascript:/i;
+
+/** Returns the value unchanged if it is a safe CSS token, otherwise undefined. */
+export function safeCssValue(value: string | undefined): string | undefined {
+  return value && !UNSAFE_CSS.test(value) ? value : undefined;
+}
 const toKebab = (s: string) => s.replace(/([A-Z])/g, "-$1").toLowerCase();
 const toCssVars = (tokens: Record<string, string>) =>
   Object.entries(tokens)

--- a/frontend/src/app/index.tsx
+++ b/frontend/src/app/index.tsx
@@ -1,6 +1,7 @@
 import { signOut } from "@/auth/keycloak";
 import { useUser } from "@/auth/user";
 
+import { Banner } from "../components/Banner";
 import { Content } from "../components/Content";
 import { Header } from "../components/Header";
 import { useTheme } from "../hooks/ThemeContext";
@@ -16,6 +17,7 @@ export default function App() {
 
   return (
     <main className="w-full">
+      <Banner config={config?.banners?.top} />
       <Header
         isDarkMode={isDarkMode}
         themeMode={themeMode}
@@ -29,6 +31,7 @@ export default function App() {
       />
 
       <Content services={services} onTogglePin={onTogglePin} />
+      <Banner config={config?.banners?.bottom} />
     </main>
   );
 }

--- a/frontend/src/components/Banner.tsx
+++ b/frontend/src/components/Banner.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from "react";
+import { type BannerConfig, safeCssValue } from "../app/config";
+
+export type BannerProps = {
+  config?: BannerConfig;
+};
+
+/**
+ * Full-width classification banner (e.g. CUI) rendered above the header or
+ * below the page content. Configured at runtime via /config.json — see
+ * AppConfig.banners. Renders nothing when no text is configured.
+ *
+ * Text is rendered as plain text (never HTML). Color values pass through the
+ * same UNSAFE_CSS guard as theme tokens; unsafe values fall back to the
+ * theme's inverted colors, which follow light/dark mode.
+ */
+export function Banner({ config }: BannerProps): ReactNode {
+  if (!config?.text) return null;
+
+  const background = safeCssValue(config.background);
+  const foreground = safeCssValue(config.foreground);
+
+  return (
+    <div
+      role="note"
+      className="w-full bg-foreground py-1 text-center text-sm font-semibold text-background"
+      style={{ backgroundColor: background, color: foreground }}
+    >
+      {config.text}
+    </div>
+  );
+}

--- a/frontend/tests/unit/app/App.banners.test.tsx
+++ b/frontend/tests/unit/app/App.banners.test.tsx
@@ -1,0 +1,54 @@
+import { renderWithProviders as render } from "@/test/render";
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/auth/keycloak", () => ({ signOut: vi.fn() }));
+vi.mock("@/auth/user", () => ({ useUser: () => ({ user: null }) }));
+vi.mock("@/hooks/useLaunchpadData", () => ({
+  useLaunchpadData: () => ({
+    services: [],
+    notifications: [],
+    onNotificationsViewed: vi.fn(),
+    onTogglePin: vi.fn(),
+  }),
+}));
+vi.mock("@/app/config", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/app/config")>()),
+  getAppConfig: vi.fn(),
+}));
+
+import { getAppConfig } from "@/app/config";
+import App from "@/app/index";
+
+const mockedGetAppConfig = vi.mocked(getAppConfig);
+
+const baseConfig = {
+  keycloak: { url: "http://localhost", realm: "nebari", clientId: "spa" },
+};
+
+beforeEach(() => {
+  mockedGetAppConfig.mockReturnValue(baseConfig);
+});
+
+describe("App banners", () => {
+  it("renders a top banner above the header and a bottom banner below the content", () => {
+    mockedGetAppConfig.mockReturnValue({
+      ...baseConfig,
+      banners: { top: { text: "CUI TOP" }, bottom: { text: "CUI BOTTOM" } },
+    });
+
+    render(<App />);
+
+    const top = screen.getByText("CUI TOP");
+    const bottom = screen.getByText("CUI BOTTOM");
+    const header = screen.getByRole("banner");
+
+    expect(top.compareDocumentPosition(header) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(header.compareDocumentPosition(bottom) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("renders no banners when none are configured", () => {
+    render(<App />);
+    expect(screen.queryByRole("note")).toBeNull();
+  });
+});

--- a/frontend/tests/unit/components/Banner.test.tsx
+++ b/frontend/tests/unit/components/Banner.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Banner } from "@/components/Banner";
+
+describe("Banner", () => {
+  it("renders the configured text", () => {
+    render(<Banner config={{ text: "CUI" }} />);
+    expect(screen.getByText("CUI")).toBeInTheDocument();
+  });
+
+  it("renders nothing when config is absent", () => {
+    const { container } = render(<Banner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when text is empty", () => {
+    const { container } = render(<Banner config={{ text: "" }} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("applies configured background and foreground colors", () => {
+    render(<Banner config={{ text: "CUI", background: "#502b85", foreground: "#ffffff" }} />);
+    const banner = screen.getByText("CUI");
+    expect(banner).toHaveStyle({ backgroundColor: "#502b85", color: "#ffffff" });
+  });
+
+  it("ignores unsafe color values", () => {
+    render(
+      <Banner
+        config={{
+          text: "CUI",
+          background: 'red; background-image: url("https://evil.example/x")',
+          foreground: "expression(alert(1))",
+        }}
+      />,
+    );
+    const banner = screen.getByText("CUI");
+    expect(banner.style.backgroundColor).toBe("");
+    expect(banner.style.color).toBe("");
+  });
+
+  it("treats banner text as plain text, not HTML", () => {
+    render(<Banner config={{ text: "<b>CUI</b>" }} />);
+    const banner = screen.getByText("<b>CUI</b>");
+    expect(banner.querySelector("b")).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes https://github.com/nebari-dev/nebari-landing/issues/144

Extends the runtime branding configuration with optional **top** and **bottom** classification banners (the U.S. government CUI pattern) rendered above the header and below the page content. Like existing branding, banners are configured at runtime via `frontend.branding.banners.*` in the Helm chart (`values.yaml` → `/config.json`) with no image rebuild.

## Changes

- `frontend/src/app/config.ts`: new `BannerConfig` type (`text`, `background?`, `foreground?`), `banners?: { top?, bottom? }` on `AppConfig`, and an exported `safeCssValue()` helper reusing the existing `UNSAFE_CSS` guard.
- `frontend/src/components/Banner.tsx`: full-width centered banner. Text renders as plain text (no `dangerouslySetInnerHTML`); unsafe color values are dropped, falling back to theme-inverted colors that follow light/dark mode. Renders nothing when `text` is absent, so default deployments have no layout shift.
- `frontend/src/app/index.tsx`: top banner above `<Header>`, bottom banner below `<Content>`.
- `charts/nebari-landing/values.yaml`: documented `frontend.branding.banners.top/bottom` keys, defaulting to empty/disabled.
- `charts/nebari-landing/templates/frontend/configmap.yaml`: renders banners into `config.json`.
- `frontend/public/config.json`: empty banner keys for local dev parity.

## Tests

- `Banner.test.tsx`: renders when configured, absent when not, applies safe colors, rejects unsafe color values, plain-text-only rendering.
- `App.banners.test.tsx`: top banner precedes the header, bottom banner follows the content; no `role=note` elements when unconfigured.
- `vitest run` (42 tests), `biome check`, `npm run build`, and `helm lint` all pass; `helm template` verified with and without banner values (valid JSON in both cases).