### PR TITLE
fix(frontend): restore data:image URIs in sanitizeUrl (regression from #110)

### DIFF
--- a/frontend/src/app/config.ts
+++ b/frontend/src/app/config.ts
@@ -70,14 +70,45 @@ export async function loadAppConfig(): Promise<AppConfig> {
   return _config;
 }
 
-// Accept only non-empty, well-formed http(s) URLs or root-relative paths;
-// anything else (including "") becomes undefined.
+// Accept root-relative paths, http(s) URLs, and data: URIs for a
+// safe-listed set of image MIME types. Anything else (including "")
+// becomes undefined.
+//
+// Data URIs were supported before PR #110 introduced this sanitizer; the
+// restriction to http(s) accidentally broke deployers who ship the logo /
+// favicon inline via `frontend.branding.logoUrl` in the chart values.
+// Restoring data-URI support keeps the defence-in-depth (no javascript:,
+// no data:text/html, etc.) while unblocking the previously-working
+// inline-image pattern.
+const ALLOWED_DATA_MIME_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/jpg",
+  "image/svg+xml",
+  "image/webp",
+  "image/gif",
+  "image/x-icon",
+  "image/vnd.microsoft.icon",
+]);
+
 function sanitizeUrl(value: string | undefined): string | undefined {
   if (!value) return undefined;
   if (value.startsWith("/")) return value;
   try {
     const { protocol } = new URL(value);
-    return protocol === "http:" || protocol === "https:" ? value : undefined;
+    if (protocol === "http:" || protocol === "https:") return value;
+    if (protocol === "data:") {
+      // Format: data:<mime>[;base64],<data>
+      // Only accept base64-encoded images from the allow-list; reject
+      // text/html, javascript, and everything else.
+      const match = /^data:([^;,]+)(;base64)?,/.exec(value);
+      if (!match) return undefined;
+      const mime = match[1].toLowerCase();
+      const isBase64 = Boolean(match[2]);
+      if (isBase64 && ALLOWED_DATA_MIME_TYPES.has(mime)) return value;
+      return undefined;
+    }
+    return undefined;
   } catch {
     return undefined;
   }


### PR DESCRIPTION
## Summary

Restore support for `data:image/*;base64,...` URIs in `frontend/src/app/config.ts`'s `sanitizeUrl`. Data URIs for logos and favicons were a supported branding pattern before PR #110 landed the sanitizer and are still a common way for deployers to embed small images inline via the chart's `frontend.branding.logoUrl` / `logoUrlDark` / `faviconUrl` values (no external hosting infra, no separate ConfigMap for image bytes). They break silently under the current code — data URIs get replaced with `undefined` and the SPA falls back to the built-in logo without logging anything.

## The regression

- Introduced in [#110 (Dark mode logo)](https://github.com/nebari-dev/nebari-landing/pull/110), commit `8f9eddd`, 2026-06-09
- First tagged release with the regression: `v0.1.0` (2026-06-29)
- Silent — no console warning, no visible error; the SPA just falls back to the built-in Nebari logo

The intent of the sanitizer is defence-in-depth against `javascript:`, `data:text/html`, and similar unsafe URL shapes reaching an `<img src>` attribute. Data URIs of safe image MIME types don't carry that risk — allowing them keeps the sanitizer's guarantee while unbreaking the pre-#110 use case.

## Change

`sanitizeUrl` now accepts:

- Root-relative paths (`/logo.png`) — unchanged
- `http:` / `https:` URLs — unchanged
- `data:<safe-image-mime>;base64,<payload>` — new (regression fix)

Anything else — including `data:text/html`, `data:application/javascript`, `javascript:`, `file:`, non-base64 data URIs, and malformed values — still returns `undefined`.

The safe MIME allow-list:

- `image/png`
- `image/jpeg`, `image/jpg`
- `image/svg+xml`
- `image/webp`
- `image/gif`
- `image/x-icon`, `image/vnd.microsoft.icon`

Non-base64 data URIs (e.g. `data:image/svg+xml,<svg>...</svg>`) are rejected — base64 encoding is required so we can be confident about what shape the payload has.

## Real-world impact

We hit this after bumping our infra from `v0.1.0-alpha.5` (which predates `sanitizeUrl`) to `v0.1.3`. Our chart values embed the customer's logo and favicon as base64-encoded PNG data URIs — worked cleanly before, silently reverted to the default logo after the bump. Adding a similar allow-list would restore the pattern without weakening the sanitizer's threat model.

## Test plan

Manual verification of both preserved and newly-accepted values:

| Input | Before this PR | After this PR |
| --- | --- | --- |
| `/logo.png` | accepted | accepted |
| `https://example.com/logo.png` | accepted | accepted |
| `data:image/png;base64,iVBORw0KG...` | dropped ❌ | accepted ✅ |
| `data:image/svg+xml;base64,PHN2Zy...` | dropped ❌ | accepted ✅ |
| `data:image/svg+xml,<svg>...</svg>` | dropped ❌ | dropped ❌ (base64 required) |
| `data:text/html;base64,PHNjcmlwdD...` | dropped ❌ | dropped ❌ (not in allow-list) |
| `javascript:alert(1)` | dropped ❌ | dropped ❌ |
| `""` | dropped ❌ | dropped ❌ |

I didn't add a unit test in this PR because `sanitizeUrl` is a private function in the module; testing it in isolation would require either exporting it (arguably useful) or a `loadAppConfig()` roundtrip with a mocked `fetch`. Happy to add either flavour if you'd prefer — just say which.
