### PR TITLE
fix(frontend): sanitize faviconUrl through sanitizeUrl

### DIFF
--- a/frontend/src/app/config.ts
+++ b/frontend/src/app/config.ts
@@ -67,6 +67,7 @@ export async function loadAppConfig(): Promise<AppConfig> {
   // (defence-in-depth, mirroring the theme-token sanitisation below).
   _config.logoUrl = sanitizeUrl(_config.logoUrl);
   _config.logoUrlDark = sanitizeUrl(_config.logoUrlDark);
+  _config.faviconUrl = sanitizeUrl(_config.faviconUrl);
   return _config;
 }
 

--- a/frontend/tests/unit/app/config.test.ts
+++ b/frontend/tests/unit/app/config.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// loadAppConfig() caches its result at module scope and only fetches once, so
+// each case resets the module registry and re-imports a fresh copy.
+async function loadWith(config: Record<string, unknown>) {
+  vi.resetModules();
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => new Response(JSON.stringify(config), { status: 200 })),
+  );
+  const { loadAppConfig } = await import("@/app/config");
+  return loadAppConfig();
+}
+
+const baseConfig = {
+  keycloak: { url: "http://localhost", realm: "nebari", clientId: "spa" },
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("loadAppConfig faviconUrl sanitization", () => {
+  it("preserves a base64 image data URI", async () => {
+    const favicon = "data:image/png;base64,iVBORw0KGgo=";
+    const config = await loadWith({ ...baseConfig, faviconUrl: favicon });
+    expect(config.faviconUrl).toBe(favicon);
+  });
+
+  it("preserves http(s) and root-relative favicons", async () => {
+    expect(
+      (await loadWith({ ...baseConfig, faviconUrl: "https://example.com/f.ico" }))
+        .faviconUrl,
+    ).toBe("https://example.com/f.ico");
+    expect(
+      (await loadWith({ ...baseConfig, faviconUrl: "/favicon.ico" })).faviconUrl,
+    ).toBe("/favicon.ico");
+  });
+
+  it("drops a javascript: favicon", async () => {
+    const config = await loadWith({ ...baseConfig, faviconUrl: "javascript:alert(1)" });
+    expect(config.faviconUrl).toBeUndefined();
+  });
+
+  it("drops a data:text/html favicon", async () => {
+    const config = await loadWith({
+      ...baseConfig,
+      faviconUrl: "data:text/html;base64,PHNjcmlwdD4=",
+    });
+    expect(config.faviconUrl).toBeUndefined();
+  });
+
+  it("drops a malformed favicon", async () => {
+    const config = await loadWith({ ...baseConfig, faviconUrl: "not a url" });
+    expect(config.faviconUrl).toBeUndefined();
+  });
+});

--- a/frontend/tests/unit/app/config.test.ts
+++ b/frontend/tests/unit/app/config.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 // loadAppConfig() caches its result at module scope and only fetches once, so
 // each case resets the module registry and re-imports a fresh copy.


### PR DESCRIPTION
## Summary

`faviconUrl` from `config.json` was assigned directly to a `<link rel="icon">` href in `applyAppConfig()` (`frontend/src/app/config.ts`) without passing through `sanitizeUrl`, while `logoUrl` and `logoUrlDark` were sanitized in `loadAppConfig()`. This routes `faviconUrl` through the same sanitizer.

Surfaced during review of #173 (which restored `data:image/*;base64` support in `sanitizeUrl`). That PR's framing mentions favicons, but the favicon path never touched the sanitizer, so the image MIME allow-list didn't actually cover it — and the sink was left unguarded relative to the sanitizer's defence-in-depth intent.

## Change

- `loadAppConfig()` now sanitizes `faviconUrl` via `sanitizeUrl`, consistent with `logoUrl` / `logoUrlDark`.
- Safe values (base64 image data URI, `http(s)`, root-relative) are preserved; unsafe values (`javascript:`, `data:text/html`, malformed) become `undefined` and no custom favicon is applied.

## Test plan

Adds `frontend/tests/unit/app/config.test.ts` covering accepted and rejected favicon values via a `loadAppConfig()` roundtrip with mocked `fetch`.

- [x] `npx vitest run` — 47/47 pass (13 files)
- [x] `npx tsc --noEmit` clean
- [x] `npx biome check src/app/config.ts` clean

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)