### PR TITLE
Harden JWKS refresh handling

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -327,6 +327,9 @@ func main() {
 		// Per-frame write deadlines are enforced inside the Hub.Broadcast instead.
 		WriteTimeout: 0,
 		IdleTimeout:  60 * time.Second,
+		// Bound aggregate request headers before they reach handler code. The
+		// API applies a tighter Authorization-specific cap before JWT parsing.
+		MaxHeaderBytes: 128 * 1024,
 	}
 
 	go func() {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/onsi/gomega v1.38.2
 	github.com/redis/go-redis/v9 v9.18.0
+	golang.org/x/sync v0.18.0
 	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.2
 	k8s.io/client-go v0.35.2
@@ -71,7 +72,6 @@ require (
 	golang.org/x/mod v0.29.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
-	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/term v0.37.0 // indirect
 	golang.org/x/text v0.31.0 // indirect

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/nebari-dev/nebari-landing/internal/accessrequests"
@@ -21,6 +23,14 @@ import (
 )
 
 var log = ctrl.Log.WithName("api")
+
+const (
+	maxAuthorizationHeaderBytes = 64*1024 + len("Bearer ")
+	authFailureWindow           = time.Minute
+	authFailurePerSourceLimit   = 60
+	authFailureGlobalLimit      = 600
+	authFailureMaxSources       = 4096
+)
 
 // Handler handles HTTP requests for the landing page API
 type Handler struct {
@@ -56,6 +66,10 @@ type Handler struct {
 	// Use WithClaimsExtractor in tests to inject synthetic claims without
 	// needing a real Keycloak instance or signed token.
 	claimsExtractor func(*http.Request) (*auth.Claims, bool)
+	// authFailureLimiter dampens repeated bad-token validation work by source
+	// and globally. It is process-local and intentionally applies only after
+	// observed validation failures; valid traffic is not pre-emptively charged.
+	authFailureLimiter *authFailureLimiter
 	// wsTicketStore, when non-nil, enables the POST /api/v1/ws-ticket endpoint.
 	// Browsers cannot send Authorization headers on WebSocket upgrade requests,
 	// so the frontend exchanges a short-lived single-use ticket via that endpoint
@@ -151,6 +165,12 @@ func NewHandler(serviceCache *cache.ServiceCache, jwtValidator *auth.JWTValidato
 		pinStore:       pinStore,
 		adminGroup:     "admin",
 		allowedOrigins: []string{"*"},
+		authFailureLimiter: newAuthFailureLimiter(
+			authFailureWindow,
+			authFailurePerSourceLimit,
+			authFailureGlobalLimit,
+			authFailureMaxSources,
+		),
 	}
 	for _, opt := range opts {
 		opt(h)
@@ -169,6 +189,7 @@ func (h *Handler) Routes() http.Handler {
 	mux.HandleFunc("/api/v1/health", h.handleHealth)
 	mux.HandleFunc("/api/v1/notifications", h.handleGetNotifications)
 	mux.HandleFunc("/api/v1/notifications/", h.handleNotificationSub) // /{id}/read
+	mux.HandleFunc("/metrics", h.handleMetrics)
 
 	// WebSocket — real-time service updates
 	if h.hub != nil {
@@ -330,6 +351,144 @@ func expFromClaims(claims *auth.Claims) time.Time {
 		return time.Time{}
 	}
 	return claims.ExpiresAt.Time
+}
+
+type authFailureBucket struct {
+	windowStart time.Time
+	count       int
+}
+
+type authFailureLimiter struct {
+	mu             sync.Mutex
+	window         time.Duration
+	perSourceLimit int
+	globalLimit    int
+	maxSources     int
+	sources        map[string]authFailureBucket
+	global         authFailureBucket
+	now            func() time.Time
+}
+
+func newAuthFailureLimiter(window time.Duration, perSourceLimit, globalLimit, maxSources int) *authFailureLimiter {
+	return &authFailureLimiter{
+		window:         window,
+		perSourceLimit: perSourceLimit,
+		globalLimit:    globalLimit,
+		maxSources:     maxSources,
+		sources:        make(map[string]authFailureBucket),
+		now:            time.Now,
+	}
+}
+
+func (l *authFailureLimiter) limited(source string) bool {
+	if l == nil {
+		return false
+	}
+	now := l.now()
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.global.resetIfExpired(now, l.window)
+	sourceBucket := l.sourceBucketLocked(source, now)
+	return l.globalLimit > 0 && l.global.count >= l.globalLimit ||
+		l.perSourceLimit > 0 && sourceBucket.count >= l.perSourceLimit
+}
+
+func (l *authFailureLimiter) recordFailure(source string) {
+	if l == nil {
+		return
+	}
+	now := l.now()
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.global.resetIfExpired(now, l.window)
+	l.global.count++
+
+	sourceBucket := l.sourceBucketLocked(source, now)
+	sourceBucket.count++
+	l.sources[source] = sourceBucket
+}
+
+func (l *authFailureLimiter) recordSuccess(source string) {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	delete(l.sources, source)
+	l.mu.Unlock()
+}
+
+func (l *authFailureLimiter) sourceBucketLocked(source string, now time.Time) authFailureBucket {
+	if source == "" {
+		source = "unknown"
+	}
+	sourceBucket := l.sources[source]
+	sourceBucket.resetIfExpired(now, l.window)
+
+	if _, exists := l.sources[source]; !exists && l.maxSources > 0 && len(l.sources) >= l.maxSources {
+		l.pruneSourcesLocked(now)
+	}
+	if _, exists := l.sources[source]; !exists && l.maxSources > 0 && len(l.sources) >= l.maxSources {
+		for cachedSource := range l.sources {
+			delete(l.sources, cachedSource)
+			break
+		}
+	}
+	l.sources[source] = sourceBucket
+	return sourceBucket
+}
+
+func (l *authFailureLimiter) pruneSourcesLocked(now time.Time) {
+	for source, bucket := range l.sources {
+		bucket.resetIfExpired(now, l.window)
+		if bucket.count == 0 {
+			delete(l.sources, source)
+		}
+	}
+}
+
+func (b *authFailureBucket) resetIfExpired(now time.Time, window time.Duration) {
+	if b.windowStart.IsZero() || window <= 0 || now.Sub(b.windowStart) >= window {
+		b.windowStart = now
+		b.count = 0
+	}
+}
+
+func requestSource(r *http.Request) string {
+	// nginx appends its direct peer address to X-Forwarded-For before proxying
+	// to the webapi; use that rightmost entry so client-supplied prefixes cannot
+	// pick their own rate-limit bucket.
+	if forwardedFor := r.Header.Get("X-Forwarded-For"); forwardedFor != "" {
+		parts := strings.Split(forwardedFor, ",")
+		if source := normalizeIP(parts[len(parts)-1]); source != "" {
+			return source
+		}
+	}
+	if source := normalizeIP(r.Header.Get("X-Real-IP")); source != "" {
+		return source
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err == nil && host != "" {
+		return host
+	}
+	if r.RemoteAddr != "" {
+		return r.RemoteAddr
+	}
+	return "unknown"
+}
+
+func normalizeIP(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if ip := net.ParseIP(value); ip != nil {
+		return ip.String()
+	}
+	return ""
 }
 
 // WSTicketResponse is the response body for POST /api/v1/ws-ticket.
@@ -1131,17 +1290,85 @@ func (h *Handler) handleHealth(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (h *Handler) handleMetrics(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+
+	configured := 0
+	if h.jwtValidator != nil {
+		configured = 1
+	}
+	fmt.Fprintf(w, "# HELP nebari_landing_jwt_validator_configured Whether the JWT validator is configured.\n")
+	fmt.Fprintf(w, "# TYPE nebari_landing_jwt_validator_configured gauge\n")
+	fmt.Fprintf(w, "nebari_landing_jwt_validator_configured %d\n", configured)
+
+	if h.jwtValidator == nil {
+		return
+	}
+
+	stats := h.jwtValidator.Stats()
+	ready := 0
+	if stats.Ready {
+		ready = 1
+	}
+
+	fmt.Fprintf(w, "# HELP nebari_landing_jwt_validator_ready Whether initial JWKS loading has completed.\n")
+	fmt.Fprintf(w, "# TYPE nebari_landing_jwt_validator_ready gauge\n")
+	fmt.Fprintf(w, "nebari_landing_jwt_validator_ready %d\n", ready)
+	fmt.Fprintf(w, "# HELP nebari_landing_jwt_validator_keys Cached JWT signing keys.\n")
+	fmt.Fprintf(w, "# TYPE nebari_landing_jwt_validator_keys gauge\n")
+	fmt.Fprintf(w, "nebari_landing_jwt_validator_keys %d\n", stats.KeyCount)
+	if !stats.LastFetch.IsZero() {
+		fmt.Fprintf(w, "# HELP nebari_landing_jwt_validator_last_fetch_timestamp_seconds Last successful JWKS fetch time.\n")
+		fmt.Fprintf(w, "# TYPE nebari_landing_jwt_validator_last_fetch_timestamp_seconds gauge\n")
+		fmt.Fprintf(w, "nebari_landing_jwt_validator_last_fetch_timestamp_seconds %d\n", stats.LastFetch.Unix())
+	}
+	if !stats.LastRefreshAttempt.IsZero() {
+		fmt.Fprintf(w, "# HELP nebari_landing_jwt_validator_last_refresh_attempt_timestamp_seconds Last attempted JWKS refresh time.\n")
+		fmt.Fprintf(w, "# TYPE nebari_landing_jwt_validator_last_refresh_attempt_timestamp_seconds gauge\n")
+		fmt.Fprintf(w, "nebari_landing_jwt_validator_last_refresh_attempt_timestamp_seconds %d\n", stats.LastRefreshAttempt.Unix())
+	}
+
+	fmt.Fprintf(w, "# HELP nebari_landing_jwks_refresh_attempts_total JWKS refresh attempts.\n")
+	fmt.Fprintf(w, "# TYPE nebari_landing_jwks_refresh_attempts_total counter\n")
+	fmt.Fprintf(w, "nebari_landing_jwks_refresh_attempts_total %d\n", stats.JWKSRefreshAttempts)
+	fmt.Fprintf(w, "# HELP nebari_landing_jwks_refresh_successes_total Successful JWKS refreshes.\n")
+	fmt.Fprintf(w, "# TYPE nebari_landing_jwks_refresh_successes_total counter\n")
+	fmt.Fprintf(w, "nebari_landing_jwks_refresh_successes_total %d\n", stats.JWKSRefreshSuccesses)
+	fmt.Fprintf(w, "# HELP nebari_landing_jwks_refresh_failures_total Failed JWKS refreshes.\n")
+	fmt.Fprintf(w, "# TYPE nebari_landing_jwks_refresh_failures_total counter\n")
+	fmt.Fprintf(w, "nebari_landing_jwks_refresh_failures_total %d\n", stats.JWKSRefreshFailures)
+	fmt.Fprintf(w, "# HELP nebari_landing_jwks_refresh_skipped_total JWKS refreshes skipped by cooldown.\n")
+	fmt.Fprintf(w, "# TYPE nebari_landing_jwks_refresh_skipped_total counter\n")
+	fmt.Fprintf(w, "nebari_landing_jwks_refresh_skipped_total %d\n", stats.JWKSRefreshSkipped)
+	fmt.Fprintf(w, "# HELP nebari_landing_jwks_refresh_coalesced_total JWKS refreshes coalesced while another refresh was running.\n")
+	fmt.Fprintf(w, "# TYPE nebari_landing_jwks_refresh_coalesced_total counter\n")
+	fmt.Fprintf(w, "nebari_landing_jwks_refresh_coalesced_total %d\n", stats.JWKSRefreshCoalesced)
+	fmt.Fprintf(w, "# HELP nebari_landing_unknown_kid_total JWTs that referenced an unknown key ID.\n")
+	fmt.Fprintf(w, "# TYPE nebari_landing_unknown_kid_total counter\n")
+	fmt.Fprintf(w, "nebari_landing_unknown_kid_total %d\n", stats.UnknownKIDTotal)
+	fmt.Fprintf(w, "# HELP nebari_landing_unknown_kid_cache_hits_total Unknown key IDs rejected from the negative cache.\n")
+	fmt.Fprintf(w, "# TYPE nebari_landing_unknown_kid_cache_hits_total counter\n")
+	fmt.Fprintf(w, "nebari_landing_unknown_kid_cache_hits_total %d\n", stats.UnknownKIDCacheHits)
+	fmt.Fprintf(w, "# HELP nebari_landing_unknown_kid_cache_entries Unknown key IDs currently held in the negative cache.\n")
+	fmt.Fprintf(w, "# TYPE nebari_landing_unknown_kid_cache_entries gauge\n")
+	fmt.Fprintf(w, "nebari_landing_unknown_kid_cache_entries %d\n", stats.UnknownKIDCacheEntries)
+}
+
 // extractAndValidateJWT returns the parsed claims for the request, a boolean
 // indicating whether validation succeeded, and an error.
 //
-// The error is non-nil only when the caller presented credentials but the JWT
-// validator's initial JWKS fetch has not yet completed (auth.ErrNotReady). All
-// other failure modes — missing header, malformed scheme, bad signature, wrong
-// issuer — return (nil, false, nil) so the caller can treat the request as
-// anonymous. Callers that gate behavior on auth (returning a 401/403/private
-// data) should check the error first and emit 503 + Retry-After via
-// writeAuthWarmupResponse so clients distinguish "auth offline" from "your
-// token is bad" (401) or "your stuff disappeared" (silent anonymous).
+// The ErrNotReady error is returned when the caller presented credentials but
+// the JWT validator's initial JWKS fetch has not yet completed. Other
+// validation failures are returned only for diagnostics; callers keep treating
+// them as unauthenticated by checking the authenticated boolean. Callers that
+// gate behavior on auth should check ErrNotReady first and emit 503 +
+// Retry-After via writeAuthWarmupResponse so clients distinguish "auth offline"
+// from "your token is bad" (401) or "your stuff disappeared" (silent anonymous).
 func (h *Handler) extractAndValidateJWT(r *http.Request) (*auth.Claims, bool, error) {
 	// Test/debug hook: use the injected extractor when present.
 	if h.claimsExtractor != nil {
@@ -1165,15 +1392,25 @@ func (h *Handler) extractAndValidateJWT(r *http.Request) (*auth.Claims, bool, er
 		}
 		return nil, false, nil
 	}
+	if len(authHeader) > maxAuthorizationHeaderBytes {
+		log.Info("Authorization header too large",
+			"bytes", len(authHeader), "maxBytes", maxAuthorizationHeaderBytes, "path", r.URL.Path)
+		return nil, false, fmt.Errorf("Authorization header exceeds maximum size of %d bytes", maxAuthorizationHeaderBytes)
+	}
 
 	parts := strings.Split(authHeader, " ")
 	if len(parts) != 2 || parts[0] != "Bearer" {
 		log.Info("Invalid Authorization header format",
 			"scheme", parts[0], "path", r.URL.Path)
-		return nil, false, nil
+		return nil, false, fmt.Errorf("Authorization header is not in 'Bearer <token>' format")
 	}
 
 	tokenString := parts[1]
+	source := requestSource(r)
+	if h.authFailureLimiter != nil && h.authFailureLimiter.limited(source) {
+		log.Info("JWT validation temporarily rate limited", "source", source, "path", r.URL.Path)
+		return nil, false, fmt.Errorf("JWT validation temporarily rate limited")
+	}
 
 	claims, err := h.jwtValidator.ValidateToken(tokenString)
 	if err != nil {
@@ -1182,11 +1419,17 @@ func (h *Handler) extractAndValidateJWT(r *http.Request) (*auth.Claims, bool, er
 			// degrading the user to anonymous during the warmup window.
 			return nil, false, err
 		}
+		if h.authFailureLimiter != nil {
+			h.authFailureLimiter.recordFailure(source)
+		}
 		log.Info("JWT validation failed",
 			"error", err.Error(),
 			"path", r.URL.Path,
 			"hint", "check KEYCLOAK_ISSUER_URL matches the 'iss' claim in the token")
-		return nil, false, nil
+		return nil, false, err
+	}
+	if h.authFailureLimiter != nil {
+		h.authFailureLimiter.recordSuccess(source)
 	}
 
 	if h.debugMode {
@@ -1471,13 +1714,14 @@ type DebugRequestInfo struct {
 
 // DebugAuthInfo is the auth section of the debug response.
 type DebugAuthInfo struct {
-	Enabled             bool     `json:"enabled"`
-	ValidatorConfigured bool     `json:"validator_configured"`
-	Authenticated       bool     `json:"authenticated"`
-	Username            string   `json:"username,omitempty"`
-	Email               string   `json:"email,omitempty"`
-	Groups              []string `json:"groups,omitempty"`
-	ValidationError     string   `json:"validation_error,omitempty"`
+	Enabled             bool                 `json:"enabled"`
+	ValidatorConfigured bool                 `json:"validator_configured"`
+	Authenticated       bool                 `json:"authenticated"`
+	Username            string               `json:"username,omitempty"`
+	Email               string               `json:"email,omitempty"`
+	Groups              []string             `json:"groups,omitempty"`
+	ValidationError     string               `json:"validation_error,omitempty"`
+	JWTValidator        *auth.ValidatorStats `json:"jwt_validator,omitempty"`
 }
 
 // DebugServiceCounts is the service-cache section of the debug response.
@@ -1515,17 +1759,19 @@ func (h *Handler) handleDebug(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Resolve auth state.
-	// When a claimsExtractor is configured (test / dev injection) or when the full
-	// JWT validator is available, extractAndValidateJWT already handles everything.
-	// For the debug response we also want to surface the validation *error* when
-	// the real validator is present, so we run the two paths in parallel. The
-	// ErrNotReady signal is intentionally discarded — debug should still serve
-	// during warmup so operators can see the reason in ValidationError below.
-	claims, authenticated, _ := h.extractAndValidateJWT(r)
+	// When a claimsExtractor is configured (test / dev injection) or when the
+	// full JWT validator is available, extractAndValidateJWT already handles
+	// everything. Debug surfaces validation errors instead of converting
+	// ErrNotReady to a 503 so operators can inspect auth during warmup.
+	claims, authenticated, validationErr := h.extractAndValidateJWT(r)
 
 	authInfo := DebugAuthInfo{
 		Enabled:             h.enableAuth,
 		ValidatorConfigured: h.jwtValidator != nil || h.claimsExtractor != nil,
+	}
+	if h.jwtValidator != nil {
+		stats := h.jwtValidator.Stats()
+		authInfo.JWTValidator = &stats
 	}
 
 	if authenticated && claims != nil {
@@ -1540,19 +1786,16 @@ func (h *Handler) handleDebug(w http.ResponseWriter, r *http.Request) {
 			authInfo.ValidationError = "auth is disabled (ENABLE_AUTH=false)"
 		case h.jwtValidator == nil && h.claimsExtractor == nil:
 			authInfo.ValidationError = "JWT validator not configured (KEYCLOAK_URL missing?)"
+		case validationErr != nil:
+			authInfo.ValidationError = validationErr.Error()
 		default:
 			authHeader := r.Header.Get("Authorization")
 			if authHeader == "" {
 				authInfo.ValidationError = "no Authorization header present"
 			} else {
-				// Re-run validation to surface the actual error message.
 				parts := strings.Split(authHeader, " ")
 				if len(parts) != 2 || parts[0] != "Bearer" {
 					authInfo.ValidationError = "Authorization header is not in 'Bearer <token>' format"
-				} else if h.jwtValidator != nil {
-					if _, err := h.jwtValidator.ValidateToken(parts[1]); err != nil {
-						authInfo.ValidationError = err.Error()
-					}
 				}
 			}
 		}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -7,7 +7,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	sdapp "github.com/nebari-dev/nebari-landing/internal/app"
 	"github.com/nebari-dev/nebari-landing/internal/auth"
@@ -612,6 +614,92 @@ func TestHandleDebug_OnlyRegisteredWhenDebugModeEnabled(t *testing.T) {
 	}
 	if body.Auth.Enabled {
 		t.Error("expected auth.enabled=false")
+	}
+}
+
+func TestHandleDebug_IncludesJWTValidatorStatsAndCapsAuthorizationHeader(t *testing.T) {
+	h := NewHandler(cache.NewServiceCache(), &auth.JWTValidator{}, true, nil, nil, WithDebugMode())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/debug", nil)
+	req.Header.Set("Authorization", "Bearer "+strings.Repeat("a", maxAuthorizationHeaderBytes))
+	rr := httptest.NewRecorder()
+	h.Routes().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var body DebugResponse
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode debug response: %v", err)
+	}
+	if body.Auth.JWTValidator == nil {
+		t.Fatal("expected JWT validator stats in debug response")
+	}
+	if body.Auth.JWTValidator.Ready {
+		t.Error("expected zero-value validator to report ready=false")
+	}
+	if !strings.Contains(body.Auth.ValidationError, "Authorization header exceeds maximum size") {
+		t.Errorf("expected oversized header validation error, got %q", body.Auth.ValidationError)
+	}
+}
+
+func TestHandleMetrics_ExposesJWTValidatorStatsWithoutDebug(t *testing.T) {
+	h := NewHandler(cache.NewServiceCache(), &auth.JWTValidator{}, true, nil, nil)
+
+	rr := doGet(t, h.Routes(), "/metrics")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	body := rr.Body.String()
+	for _, want := range []string{
+		"nebari_landing_jwt_validator_configured 1",
+		"nebari_landing_jwt_validator_ready 0",
+		"nebari_landing_jwks_refresh_attempts_total 0",
+		"nebari_landing_unknown_kid_cache_entries 0",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("metrics response missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func TestRequestSource_UsesProxyAppendedForwardedIP(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/services", nil)
+	req.RemoteAddr = "10.2.0.15:41234"
+	req.Header.Set("X-Forwarded-For", "198.51.100.250, 203.0.113.10")
+	req.Header.Set("X-Real-IP", "10.2.0.15")
+
+	if got := requestSource(req); got != "203.0.113.10" {
+		t.Errorf("expected proxy-appended forwarded IP, got %q", got)
+	}
+}
+
+func TestAuthFailureLimiter_LimitsPerSourceAndGlobally(t *testing.T) {
+	now := time.Unix(100, 0)
+	limiter := newAuthFailureLimiter(time.Minute, 2, 3, 10)
+	limiter.now = func() time.Time { return now }
+
+	if limiter.limited("10.0.0.1") {
+		t.Fatal("fresh source should not be limited")
+	}
+	limiter.recordFailure("10.0.0.1")
+	limiter.recordFailure("10.0.0.1")
+	if !limiter.limited("10.0.0.1") {
+		t.Fatal("source should be limited after reaching source threshold")
+	}
+	if limiter.limited("10.0.0.2") {
+		t.Fatal("different source should not be source-limited before global threshold")
+	}
+
+	limiter.recordFailure("10.0.0.2")
+	if !limiter.limited("10.0.0.2") {
+		t.Fatal("all sources should be limited after reaching global threshold")
+	}
+
+	now = now.Add(time.Minute)
+	if limiter.limited("10.0.0.1") {
+		t.Fatal("source should be allowed after the window rolls over")
 	}
 }
 

--- a/internal/auth/jwt_validator.go
+++ b/internal/auth/jwt_validator.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/sync/singleflight"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -35,6 +36,22 @@ var (
 	// but long enough that an operator looking at logs sees a clear "still
 	// failing" cadence rather than a tight retry storm.
 	slowPollInterval = 30 * time.Second
+	// jwksStaleRefreshInterval is the normal background refresh cadence driven
+	// by request traffic after the validator has become ready.
+	jwksStaleRefreshInterval = time.Hour
+	// jwksRefreshMinInterval is a floor across on-demand refresh attempts. It
+	// prevents unknown-kid traffic from mapping 1:1 to outbound JWKS requests.
+	jwksRefreshMinInterval = time.Minute
+	// unknownKIDCacheTTL remembers key IDs that remained unknown after refresh.
+	unknownKIDCacheTTL = 5 * time.Minute
+	// unknownKIDCacheMaxEntries bounds memory used by the negative cache.
+	unknownKIDCacheMaxEntries = 1024
+	// maxJWTBytes is an application-level cap before jwt.ParseWithClaims sees
+	// untrusted input. Keycloak tokens are usually far smaller; 64 KiB leaves
+	// room for large group claims while bounding pathological headers.
+	maxJWTBytes = 64 * 1024
+	// maxKIDBytes bounds the untrusted JWT header value we use as a map key.
+	maxKIDBytes = 1024
 )
 
 // ErrNotReady is returned by ValidateToken when the validator's initial JWKS
@@ -42,6 +59,8 @@ var (
 // surface a 503 Service Unavailable so clients distinguish "Keycloak not
 // reachable yet" from "your token is bad" (401).
 var ErrNotReady = errors.New("jwt validator: initial JWKS fetch not yet complete")
+
+var errJWKSRefreshSkipped = errors.New("jwt validator: JWKS refresh skipped by cooldown")
 
 // Claims represents the JWT claims we care about
 type Claims struct {
@@ -79,10 +98,30 @@ type JWTValidator struct {
 	publicKeys map[string]*rsa.PublicKey
 	keysMu     sync.RWMutex
 	lastFetch  time.Time
+	// refreshGroup coalesces concurrent request-time refreshes. The initial
+	// background fetch path stays direct so startup retry logging remains simple.
+	refreshGroup singleflight.Group
+	refreshMu    sync.Mutex
+	// lastRefreshAttempt tracks failed attempts too; lastFetch only records
+	// successful key loads.
+	lastRefreshAttempt time.Time
+	refreshCall        *jwksRefreshCall
+	unknownKIDMu       sync.Mutex
+	unknownKIDs        map[string]time.Time
 	// ready flips to true once the first JWKS fetch succeeds. Reads must use
 	// atomic.Bool because the writer runs on the background init goroutine
 	// while readers run on every request-handling goroutine.
 	ready atomic.Bool
+	// Counters are intentionally process-local; they surface via Stats() and the
+	// existing debug endpoint so operators can see refresh pressure without a
+	// separate metrics subsystem.
+	jwksRefreshAttempts  atomic.Uint64
+	jwksRefreshSuccesses atomic.Uint64
+	jwksRefreshFailures  atomic.Uint64
+	jwksRefreshSkipped   atomic.Uint64
+	jwksRefreshCoalesced atomic.Uint64
+	unknownKIDTotal      atomic.Uint64
+	unknownKIDCacheHits  atomic.Uint64
 	// stopCh is closed by Stop() to interrupt the slow-poll loop. The active
 	// retry path uses retryDelay (overrideable in tests) and does not need
 	// the channel — it always completes within retryMaxAttempts iterations.
@@ -93,6 +132,27 @@ type JWTValidator struct {
 	// stopOnce guards the close(stopCh) in Stop so concurrent callers cannot
 	// double-close the channel.
 	stopOnce sync.Once
+}
+
+type jwksRefreshCall struct {
+	done chan struct{}
+	err  error
+}
+
+// ValidatorStats exposes process-local counters for JWKS refresh behavior.
+type ValidatorStats struct {
+	Ready                  bool      `json:"ready"`
+	KeyCount               int       `json:"key_count"`
+	LastFetch              time.Time `json:"last_fetch,omitempty"`
+	LastRefreshAttempt     time.Time `json:"last_refresh_attempt,omitempty"`
+	JWKSRefreshAttempts    uint64    `json:"jwks_refresh_attempts"`
+	JWKSRefreshSuccesses   uint64    `json:"jwks_refresh_successes"`
+	JWKSRefreshFailures    uint64    `json:"jwks_refresh_failures"`
+	JWKSRefreshSkipped     uint64    `json:"jwks_refresh_skipped"`
+	JWKSRefreshCoalesced   uint64    `json:"jwks_refresh_coalesced"`
+	UnknownKIDTotal        uint64    `json:"unknown_kid_total"`
+	UnknownKIDCacheHits    uint64    `json:"unknown_kid_cache_hits"`
+	UnknownKIDCacheEntries int       `json:"unknown_kid_cache_entries"`
 }
 
 // JWK represents a JSON Web Key
@@ -125,6 +185,7 @@ func NewJWTValidator(keycloakURL, realm string) *JWTValidator {
 		issuerURL:   cleanURL, // default; override with SetIssuerURL if needed
 		realm:       realm,
 		publicKeys:  make(map[string]*rsa.PublicKey),
+		unknownKIDs: make(map[string]time.Time),
 		stopCh:      make(chan struct{}),
 		doneCh:      make(chan struct{}),
 	}
@@ -210,6 +271,36 @@ func (v *JWTValidator) Ready() bool {
 	return v.ready.Load()
 }
 
+// Stats returns a snapshot of JWKS refresh and unknown-key counters.
+func (v *JWTValidator) Stats() ValidatorStats {
+	stats := ValidatorStats{
+		Ready:                v.Ready(),
+		JWKSRefreshAttempts:  v.jwksRefreshAttempts.Load(),
+		JWKSRefreshSuccesses: v.jwksRefreshSuccesses.Load(),
+		JWKSRefreshFailures:  v.jwksRefreshFailures.Load(),
+		JWKSRefreshSkipped:   v.jwksRefreshSkipped.Load(),
+		JWKSRefreshCoalesced: v.jwksRefreshCoalesced.Load(),
+		UnknownKIDTotal:      v.unknownKIDTotal.Load(),
+		UnknownKIDCacheHits:  v.unknownKIDCacheHits.Load(),
+	}
+
+	v.keysMu.RLock()
+	stats.KeyCount = len(v.publicKeys)
+	stats.LastFetch = v.lastFetch
+	v.keysMu.RUnlock()
+
+	v.refreshMu.Lock()
+	stats.LastRefreshAttempt = v.lastRefreshAttempt
+	v.refreshMu.Unlock()
+
+	v.unknownKIDMu.Lock()
+	v.pruneUnknownKIDsLocked(time.Now())
+	stats.UnknownKIDCacheEntries = len(v.unknownKIDs)
+	v.unknownKIDMu.Unlock()
+
+	return stats
+}
+
 // Stop signals the background init goroutine to exit and waits for it.
 // Safe to call multiple times, including concurrently from multiple goroutines
 // (stopOnce guards against a double-close panic). In production,
@@ -254,10 +345,8 @@ func (v *JWTValidator) ValidateToken(tokenString string) (*Claims, error) {
 		return nil, ErrNotReady
 	}
 
-	if time.Since(v.lastFetch) > time.Hour {
-		if err := v.fetchPublicKeys(); err != nil {
-			log.Error(err, "Failed to refresh public keys")
-		}
+	if len(tokenString) > maxJWTBytes {
+		return nil, fmt.Errorf("token exceeds maximum size of %d bytes", maxJWTBytes)
 	}
 
 	claims := &Claims{}
@@ -270,23 +359,41 @@ func (v *JWTValidator) ValidateToken(tokenString string) (*Claims, error) {
 		if !ok {
 			return nil, fmt.Errorf("missing kid in token header")
 		}
+		if len(kid) > maxKIDBytes {
+			return nil, fmt.Errorf("kid exceeds maximum size of %d bytes", maxKIDBytes)
+		}
 
 		v.keysMu.RLock()
-		defer v.keysMu.RUnlock()
-
 		publicKey, exists := v.publicKeys[kid]
+		v.keysMu.RUnlock()
 		if !exists {
-			// Key not cached — try a one-shot refresh (Keycloak may have rotated keys).
-			v.keysMu.RUnlock()
-			if refreshErr := v.fetchPublicKeys(); refreshErr != nil {
-				v.keysMu.RLock()
+			v.unknownKIDTotal.Add(1)
+			if v.unknownKIDCached(kid) {
+				return nil, fmt.Errorf("unknown key ID: %s (cached)", kid)
+			}
+
+			// Key not cached — try a bounded refresh (Keycloak may have rotated
+			// keys), coalesced with other callers and subject to a cooldown.
+			if refreshErr := v.refreshPublicKeysIfDue(); refreshErr != nil {
+				if errors.Is(refreshErr, errJWKSRefreshSkipped) {
+					return nil, fmt.Errorf("unknown key ID %s and key refresh skipped by cooldown: %w", kid, refreshErr)
+				}
+				v.rememberUnknownKID(kid)
 				return nil, fmt.Errorf("unknown key ID %s and key refresh failed: %w", kid, refreshErr)
 			}
 			v.keysMu.RLock()
 			publicKey, exists = v.publicKeys[kid]
+			v.keysMu.RUnlock()
 			if !exists {
-				return nil, fmt.Errorf("unknown key ID: %s (not found after key refresh)", kid)
+				v.rememberUnknownKID(kid)
+				return nil, fmt.Errorf("unknown key ID: %s (not found in current key set)", kid)
 			}
+		}
+		v.keysMu.RLock()
+		lastFetch := v.lastFetch
+		v.keysMu.RUnlock()
+		if lastFetch.IsZero() || time.Since(lastFetch) > jwksStaleRefreshInterval {
+			v.refreshPublicKeysIfDueAsync()
 		}
 
 		return publicKey, nil
@@ -317,6 +424,16 @@ func (v *JWTValidator) ValidateToken(tokenString string) (*Claims, error) {
 }
 
 func (v *JWTValidator) fetchPublicKeys() error {
+	v.jwksRefreshAttempts.Add(1)
+	if err := v.fetchPublicKeysOnce(); err != nil {
+		v.jwksRefreshFailures.Add(1)
+		return err
+	}
+	v.jwksRefreshSuccesses.Add(1)
+	return nil
+}
+
+func (v *JWTValidator) fetchPublicKeysOnce() error {
 	certsURL := fmt.Sprintf("%s/realms/%s/protocol/openid-connect/certs", v.keycloakURL, v.realm)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -346,10 +463,7 @@ func (v *JWTValidator) fetchPublicKeys() error {
 		return fmt.Errorf("failed to decode JWKS: %w", err)
 	}
 
-	v.keysMu.Lock()
-	defer v.keysMu.Unlock()
-
-	v.publicKeys = make(map[string]*rsa.PublicKey)
+	newPublicKeys := make(map[string]*rsa.PublicKey)
 
 	for _, jwk := range jwks.Keys {
 		if jwk.Kty != "RSA" {
@@ -362,18 +476,142 @@ func (v *JWTValidator) fetchPublicKeys() error {
 			continue
 		}
 
-		v.publicKeys[jwk.Kid] = publicKey
+		newPublicKeys[jwk.Kid] = publicKey
 		log.Info("Loaded public key", "kid", jwk.Kid)
 	}
 
-	v.lastFetch = time.Now()
-
-	if len(v.publicKeys) == 0 {
+	if len(newPublicKeys) == 0 {
 		return fmt.Errorf("no valid RSA keys found")
 	}
 
-	log.Info("Public keys refreshed", "count", len(v.publicKeys))
+	v.keysMu.Lock()
+	v.publicKeys = newPublicKeys
+	v.lastFetch = time.Now()
+	v.keysMu.Unlock()
+
+	log.Info("Public keys refreshed", "count", len(newPublicKeys))
 	return nil
+}
+
+func (v *JWTValidator) refreshPublicKeysIfDue() error {
+	call, skipped := v.startPublicKeysRefresh()
+	if skipped {
+		return errJWKSRefreshSkipped
+	}
+	if call == nil {
+		return nil
+	}
+	<-call.done
+	v.refreshMu.Lock()
+	err := call.err
+	v.refreshMu.Unlock()
+	return err
+}
+
+func (v *JWTValidator) refreshPublicKeysIfDueAsync() {
+	call, _ := v.startPublicKeysRefresh()
+	if call == nil {
+		return
+	}
+
+	go func() {
+		<-call.done
+		v.refreshMu.Lock()
+		err := call.err
+		v.refreshMu.Unlock()
+		if err != nil {
+			log.Error(err, "Failed to refresh public keys")
+		}
+	}()
+}
+
+func (v *JWTValidator) startPublicKeysRefresh() (*jwksRefreshCall, bool) {
+	now := time.Now()
+	v.keysMu.RLock()
+	lastFetch := v.lastFetch
+	v.keysMu.RUnlock()
+
+	v.refreshMu.Lock()
+	defer v.refreshMu.Unlock()
+
+	if v.refreshCall != nil {
+		v.jwksRefreshCoalesced.Add(1)
+		return v.refreshCall, false
+	}
+	if !v.lastRefreshAttempt.IsZero() && now.Sub(v.lastRefreshAttempt) < jwksRefreshMinInterval {
+		v.jwksRefreshSkipped.Add(1)
+		return nil, true
+	}
+	if !lastFetch.IsZero() && now.Sub(lastFetch) < jwksRefreshMinInterval {
+		v.jwksRefreshSkipped.Add(1)
+		return nil, true
+	}
+
+	v.lastRefreshAttempt = now
+	call := &jwksRefreshCall{done: make(chan struct{})}
+	v.refreshCall = call
+	ch := v.refreshGroup.DoChan("jwks-refresh", func() (interface{}, error) {
+		return nil, v.fetchPublicKeys()
+	})
+
+	go func() {
+		res := <-ch
+		v.refreshMu.Lock()
+		call.err = res.Err
+		if v.refreshCall == call {
+			v.refreshCall = nil
+		}
+		close(call.done)
+		v.refreshMu.Unlock()
+	}()
+
+	return call, false
+}
+
+func (v *JWTValidator) unknownKIDCached(kid string) bool {
+	v.unknownKIDMu.Lock()
+	defer v.unknownKIDMu.Unlock()
+
+	expiresAt, ok := v.unknownKIDs[kid]
+	if !ok {
+		return false
+	}
+	if time.Now().After(expiresAt) {
+		delete(v.unknownKIDs, kid)
+		return false
+	}
+	v.unknownKIDCacheHits.Add(1)
+	return true
+}
+
+func (v *JWTValidator) rememberUnknownKID(kid string) {
+	if unknownKIDCacheTTL <= 0 || unknownKIDCacheMaxEntries <= 0 {
+		return
+	}
+
+	now := time.Now()
+	v.unknownKIDMu.Lock()
+	defer v.unknownKIDMu.Unlock()
+
+	v.pruneUnknownKIDsLocked(now)
+	if len(v.unknownKIDs) >= unknownKIDCacheMaxEntries {
+		for cachedKID := range v.unknownKIDs {
+			delete(v.unknownKIDs, cachedKID)
+			break
+		}
+	}
+	if v.unknownKIDs == nil {
+		v.unknownKIDs = make(map[string]time.Time)
+	}
+	v.unknownKIDs[kid] = now.Add(unknownKIDCacheTTL)
+}
+
+func (v *JWTValidator) pruneUnknownKIDsLocked(now time.Time) {
+	for kid, expiresAt := range v.unknownKIDs {
+		if now.After(expiresAt) {
+			delete(v.unknownKIDs, kid)
+		}
+	}
 }
 
 func parseRSAPublicKey(jwk JWK) (*rsa.PublicKey, error) {

--- a/internal/auth/jwt_validator_test.go
+++ b/internal/auth/jwt_validator_test.go
@@ -13,6 +13,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -48,19 +49,27 @@ func eToBytes(e int) []byte {
 	return b[i:]
 }
 
-func startJWKSServer(t *testing.T, key *rsa.PrivateKey) *httptest.Server {
-	t.Helper()
-	jwks := map[string]interface{}{
+func jwkForKey(key *rsa.PrivateKey, kid string) map[string]interface{} {
+	return map[string]interface{}{
+		"kty": "RSA",
+		"kid": kid,
+		"use": "sig",
+		"n":   encodeBase64URL(key.N),
+		"e":   base64.RawURLEncoding.EncodeToString(eToBytes(key.E)),
+	}
+}
+
+func jwksForKey(key *rsa.PrivateKey) map[string]interface{} {
+	return map[string]interface{}{
 		"keys": []map[string]interface{}{
-			{
-				"kty": "RSA",
-				"kid": testKID,
-				"use": "sig",
-				"n":   encodeBase64URL(key.N),
-				"e":   base64.RawURLEncoding.EncodeToString(eToBytes(key.E)),
-			},
+			jwkForKey(key, testKID),
 		},
 	}
+}
+
+func startJWKSServer(t *testing.T, key *rsa.PrivateKey) *httptest.Server {
+	t.Helper()
+	jwks := jwksForKey(key)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(jwks)
@@ -71,6 +80,11 @@ func startJWKSServer(t *testing.T, key *rsa.PrivateKey) *httptest.Server {
 
 func signJWT(t *testing.T, key *rsa.PrivateKey, issuer string, exp time.Time, extra *Claims) string {
 	t.Helper()
+	return signJWTWithKID(t, key, issuer, exp, testKID, extra)
+}
+
+func signJWTWithKID(t *testing.T, key *rsa.PrivateKey, issuer string, exp time.Time, kid string, extra *Claims) string {
+	t.Helper()
 	if extra == nil {
 		extra = &Claims{}
 	}
@@ -80,7 +94,7 @@ func signJWT(t *testing.T, key *rsa.PrivateKey, issuer string, exp time.Time, ex
 		IssuedAt:  jwt.NewNumericDate(time.Now()),
 	}
 	tok := jwt.NewWithClaims(jwt.SigningMethodRS256, extra)
-	tok.Header["kid"] = testKID
+	tok.Header["kid"] = kid
 	s, err := tok.SignedString(key)
 	if err != nil {
 		t.Fatalf("sign: %v", err)
@@ -127,6 +141,18 @@ func waitForCalls(t *testing.T, calls *atomic.Int32, want int32, timeout time.Du
 		time.Sleep(2 * time.Millisecond)
 	}
 	t.Fatalf("expected at least %d calls within %v, got %d", want, timeout, calls.Load())
+}
+
+func waitForRefreshFailures(t *testing.T, v *JWTValidator, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if v.Stats().JWKSRefreshFailures > 0 {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("expected a JWKS refresh failure within %v", timeout)
 }
 
 // --- parseRSAPublicKey ---
@@ -291,6 +317,271 @@ func TestValidateToken_UnknownKID(t *testing.T) {
 	}
 }
 
+func TestValidateToken_UnknownKIDRefreshesAreCoalescedAndCooledDown(t *testing.T) {
+	withJWTRefreshSettings(t, 200*time.Millisecond, time.Minute, 1024)
+
+	key := generateTestKey(t)
+	jwks := jwksForKey(key)
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n > 1 {
+			time.Sleep(75 * time.Millisecond)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(jwks)
+	}))
+	defer srv.Close()
+
+	v := newValidator(t, srv)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected initial JWKS fetch only, got %d calls", got)
+	}
+
+	v.keysMu.Lock()
+	v.lastFetch = time.Now().Add(-2 * jwksStaleRefreshInterval)
+	v.keysMu.Unlock()
+
+	issuer := fmt.Sprintf("%s/realms/%s", srv.URL, testRealm)
+	const requests = 20
+	tokens := make([]string, requests)
+	for i := range tokens {
+		tokens[i] = signJWTWithKID(t, key, issuer, time.Now().Add(time.Hour), fmt.Sprintf("unknown-%d", i), nil)
+	}
+
+	start := make(chan struct{})
+	errCh := make(chan error, requests)
+	var wg sync.WaitGroup
+	for i := range tokens {
+		wg.Add(1)
+		go func(token string) {
+			defer wg.Done()
+			<-start
+			_, err := v.ValidateToken(token)
+			errCh <- err
+		}(tokens[i])
+	}
+	close(start)
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if err == nil {
+			t.Error("expected unknown kid validation to fail")
+		}
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("expected one coalesced request-time refresh, got %d JWKS calls", got)
+	}
+
+	stats := v.Stats()
+	if stats.UnknownKIDTotal != requests {
+		t.Errorf("unknown kid count: got %d, want %d", stats.UnknownKIDTotal, requests)
+	}
+	if stats.JWKSRefreshAttempts != uint64(calls.Load()) {
+		t.Errorf("refresh attempts: got %d, want %d", stats.JWKSRefreshAttempts, calls.Load())
+	}
+	if stats.JWKSRefreshCoalesced == 0 {
+		t.Error("expected concurrent refreshes to be coalesced")
+	}
+	if stats.UnknownKIDCacheEntries == 0 {
+		t.Error("expected unknown kid negative cache entries")
+	}
+}
+
+func TestValidateToken_ConcurrentRotatedKIDWaitsForSharedRefresh(t *testing.T) {
+	withJWTRefreshSettings(t, 200*time.Millisecond, time.Minute, 1024)
+
+	oldKey := generateTestKey(t)
+	newKey := generateTestKey(t)
+	const rotatedKID = "rotated-key"
+
+	oldJWKS := jwksForKey(oldKey)
+	rotatedJWKS := map[string]interface{}{
+		"keys": []map[string]interface{}{
+			jwkForKey(oldKey, testKID),
+			jwkForKey(newKey, rotatedKID),
+		},
+	}
+
+	var calls atomic.Int32
+	refreshStarted := make(chan struct{})
+	releaseRefresh := make(chan struct{})
+	var refreshOnce sync.Once
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			_ = json.NewEncoder(w).Encode(oldJWKS)
+			return
+		}
+
+		refreshOnce.Do(func() { close(refreshStarted) })
+		<-releaseRefresh
+		_ = json.NewEncoder(w).Encode(rotatedJWKS)
+	}))
+	defer srv.Close()
+
+	v := newValidator(t, srv)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected initial JWKS fetch only, got %d calls", got)
+	}
+
+	v.keysMu.Lock()
+	v.lastFetch = time.Now().Add(-2 * jwksStaleRefreshInterval)
+	v.keysMu.Unlock()
+
+	issuer := fmt.Sprintf("%s/realms/%s", srv.URL, testRealm)
+	const requests = 8
+	tokens := make([]string, requests)
+	for i := range tokens {
+		tokens[i] = signJWTWithKID(t, newKey, issuer, time.Now().Add(time.Hour), rotatedKID, &Claims{
+			PreferredUsername: fmt.Sprintf("user-%d", i),
+		})
+	}
+
+	start := make(chan struct{})
+	type validationResult struct {
+		claims *Claims
+		err    error
+	}
+	resultCh := make(chan validationResult, requests)
+	var wg sync.WaitGroup
+	for i := range tokens {
+		wg.Add(1)
+		go func(token string) {
+			defer wg.Done()
+			<-start
+			claims, err := v.ValidateToken(token)
+			resultCh <- validationResult{claims: claims, err: err}
+		}(tokens[i])
+	}
+	close(start)
+
+	select {
+	case <-refreshStarted:
+	case <-time.After(time.Second):
+		t.Fatal("request-time JWKS refresh did not start")
+	}
+	close(releaseRefresh)
+
+	wg.Wait()
+	close(resultCh)
+
+	for result := range resultCh {
+		if result.err != nil {
+			t.Errorf("rotated key should validate after shared refresh: %v", result.err)
+			continue
+		}
+		if result.claims == nil || result.claims.PreferredUsername == "" {
+			t.Errorf("expected claims from rotated token, got %#v", result.claims)
+		}
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("expected one shared request-time refresh, got %d JWKS calls", got)
+	}
+	if stats := v.Stats(); stats.JWKSRefreshCoalesced == 0 {
+		t.Error("expected concurrent rotated-key validations to share the refresh")
+	}
+}
+
+func TestValidateToken_CooldownSkippedUnknownKIDDoesNotPoisonNegativeCache(t *testing.T) {
+	withJWTRefreshSettings(t, 50*time.Millisecond, time.Minute, 1024)
+
+	oldKey := generateTestKey(t)
+	newKey := generateTestKey(t)
+	const rotatedKID = "rotated-during-cooldown"
+
+	oldJWKS := jwksForKey(oldKey)
+	rotatedJWKS := map[string]interface{}{
+		"keys": []map[string]interface{}{
+			jwkForKey(oldKey, testKID),
+			jwkForKey(newKey, rotatedKID),
+		},
+	}
+
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if n == 1 {
+			_ = json.NewEncoder(w).Encode(oldJWKS)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(rotatedJWKS)
+	}))
+	defer srv.Close()
+
+	v := newValidator(t, srv)
+	issuer := fmt.Sprintf("%s/realms/%s", srv.URL, testRealm)
+	token := signJWTWithKID(t, newKey, issuer, time.Now().Add(time.Hour), rotatedKID, &Claims{PreferredUsername: "jdoe"})
+
+	v.keysMu.Lock()
+	v.lastFetch = time.Now()
+	v.keysMu.Unlock()
+
+	if _, err := v.ValidateToken(token); err == nil || !strings.Contains(err.Error(), "key refresh skipped by cooldown") {
+		t.Fatalf("expected cooldown-skipped unknown kid error, got %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("cooldown skip should not fetch JWKS, got %d calls", got)
+	}
+	if entries := v.Stats().UnknownKIDCacheEntries; entries != 0 {
+		t.Fatalf("cooldown-skipped kid should not be negative-cached, got %d entries", entries)
+	}
+
+	time.Sleep(2 * jwksRefreshMinInterval)
+	got, err := v.ValidateToken(token)
+	if err != nil {
+		t.Fatalf("rotated key should validate after cooldown refresh: %v", err)
+	}
+	if got.PreferredUsername != "jdoe" {
+		t.Errorf("username: got %q, want jdoe", got.PreferredUsername)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("expected initial fetch plus post-cooldown refresh, got %d calls", got)
+	}
+}
+
+func TestValidateToken_UnknownKIDNegativeCacheSkipsRefreshAfterCooldown(t *testing.T) {
+	withJWTRefreshSettings(t, 10*time.Millisecond, time.Minute, 1024)
+
+	key := generateTestKey(t)
+	jwks := jwksForKey(key)
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(jwks)
+	}))
+	defer srv.Close()
+
+	v := newValidator(t, srv)
+	issuer := fmt.Sprintf("%s/realms/%s", srv.URL, testRealm)
+	token := signJWTWithKID(t, key, issuer, time.Now().Add(time.Hour), "missing-key", nil)
+
+	v.keysMu.Lock()
+	v.lastFetch = time.Now().Add(-2 * jwksStaleRefreshInterval)
+	v.keysMu.Unlock()
+	if _, err := v.ValidateToken(token); err == nil {
+		t.Fatal("expected first unknown kid validation to fail")
+	}
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("expected initial fetch plus first refresh, got %d calls", got)
+	}
+
+	time.Sleep(2 * jwksRefreshMinInterval)
+	if _, err := v.ValidateToken(token); err == nil {
+		t.Fatal("expected cached unknown kid validation to fail")
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("negative cache should skip second refresh, got %d JWKS calls", got)
+	}
+	if hits := v.Stats().UnknownKIDCacheHits; hits == 0 {
+		t.Error("expected unknown kid cache hit to be observable")
+	}
+}
+
 func TestValidateToken_Tampered(t *testing.T) {
 	key := generateTestKey(t)
 	srv := startJWKSServer(t, key)
@@ -327,6 +618,96 @@ func TestValidateToken_WrongAlgorithm(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for wrong algorithm")
 	}
+}
+
+func TestValidateToken_TooLargeTokenRejectedBeforeParsing(t *testing.T) {
+	v := &JWTValidator{}
+	v.ready.Store(true)
+
+	_, err := v.ValidateToken(strings.Repeat("a", maxJWTBytes+1))
+	if err == nil {
+		t.Fatal("expected oversized token to fail")
+	}
+}
+
+func TestValidateToken_ValidTokenSurvivesInvalidJWKSRefresh(t *testing.T) {
+	key := generateTestKey(t)
+	jwks := jwksForKey(key)
+	var invalid atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if invalid.Load() {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"keys": []interface{}{}})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(jwks)
+	}))
+	defer srv.Close()
+
+	v := newValidator(t, srv)
+	issuer := fmt.Sprintf("%s/realms/%s", srv.URL, testRealm)
+	tokenStr := signJWT(t, key, issuer, time.Now().Add(time.Hour), &Claims{PreferredUsername: "jdoe"})
+
+	invalid.Store(true)
+	v.keysMu.Lock()
+	v.lastFetch = time.Now().Add(-2 * jwksStaleRefreshInterval)
+	v.keysMu.Unlock()
+
+	got, err := v.ValidateToken(tokenStr)
+	if err != nil {
+		t.Fatalf("valid token should use last-known-good key after bad JWKS refresh: %v", err)
+	}
+	if got.PreferredUsername != "jdoe" {
+		t.Errorf("username: got %q, want jdoe", got.PreferredUsername)
+	}
+	waitForRefreshFailures(t, v, time.Second)
+}
+
+func TestValidateToken_StaleCachedKeyDoesNotWaitForJWKSRefresh(t *testing.T) {
+	key := generateTestKey(t)
+	jwks := jwksForKey(key)
+	var calls atomic.Int32
+	var blockRefresh atomic.Bool
+	releaseRefresh := make(chan struct{})
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() { close(releaseRefresh) })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		if blockRefresh.Load() {
+			<-releaseRefresh
+			http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(jwks)
+	}))
+	defer srv.Close()
+
+	v := newValidator(t, srv)
+	issuer := fmt.Sprintf("%s/realms/%s", srv.URL, testRealm)
+	tokenStr := signJWT(t, key, issuer, time.Now().Add(time.Hour), &Claims{PreferredUsername: "jdoe"})
+
+	blockRefresh.Store(true)
+	v.keysMu.Lock()
+	v.lastFetch = time.Now().Add(-2 * jwksStaleRefreshInterval)
+	v.keysMu.Unlock()
+
+	start := time.Now()
+	got, err := v.ValidateToken(tokenStr)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("valid token should use cached key while stale refresh runs: %v", err)
+	}
+	if got.PreferredUsername != "jdoe" {
+		t.Errorf("username: got %q, want jdoe", got.PreferredUsername)
+	}
+	if elapsed > 100*time.Millisecond {
+		t.Fatalf("cached-key validation waited for JWKS refresh: %v", elapsed)
+	}
+	waitForCalls(t, &calls, 2, time.Second)
+	releaseOnce.Do(func() { close(releaseRefresh) })
+	waitForRefreshFailures(t, v, time.Second)
 }
 
 // --- Claims struct ---
@@ -373,6 +754,23 @@ func withNoBackoff(t *testing.T, maxAttempts int) {
 		retryDelay = origDelay
 		retryMaxAttempts = origMax
 		retryInitialBackoff = origBackoff
+	})
+}
+
+func withJWTRefreshSettings(t *testing.T, minInterval, negativeTTL time.Duration, negativeMaxEntries int) {
+	t.Helper()
+	origMinInterval := jwksRefreshMinInterval
+	origNegativeTTL := unknownKIDCacheTTL
+	origNegativeMaxEntries := unknownKIDCacheMaxEntries
+
+	jwksRefreshMinInterval = minInterval
+	unknownKIDCacheTTL = negativeTTL
+	unknownKIDCacheMaxEntries = negativeMaxEntries
+
+	t.Cleanup(func() {
+		jwksRefreshMinInterval = origMinInterval
+		unknownKIDCacheTTL = origNegativeTTL
+		unknownKIDCacheMaxEntries = origNegativeMaxEntries
 	})
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

Closes #158 

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [x] Other (please describe): Security hardening

## Testing

- [x] Did you test the pull request locally?
- [x] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

This hardens JWT validation by coalescing request-time JWKS refreshes, adding refresh cooldowns and unknown-kid negative caching, preserving last-known-good keys during JWKS failures, bounding JWT/header sizes, rate-limiting auth failures by source and globally, and exposing JWKS/unknown-kid metrics. Possible Follow-up/or i think we should include it in this PR itself i will wait for more eyes on this, replace arbitrary eviction in the 4096-entry auth-failure source map with LRU eviction; using a map plus linked list keeps source lookup/update and least-recent eviction at O(1) average time with small memory overhead, while scan/sort-based LRU would add O(n) work.