### PR TITLE
Constrain NebariApp health checks and probe egress

### DIFF
--- a/charts/nebari-landing/templates/_helpers.tpl
+++ b/charts/nebari-landing/templates/_helpers.tpl
@@ -60,6 +60,15 @@ app.kubernetes.io/component: webapi
 {{- end }}
 
 {{/*
+Selector labels for the isolated health-prober Deployment / Service.
+*/}}
+{{- define "nebari-landing.healthProber.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nebari-landing.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: health-prober
+{{- end }}
+
+{{/*
 webapi ServiceAccount name.
 */}}
 {{- define "nebari-landing.webapi.serviceAccountName" -}}

--- a/charts/nebari-landing/templates/webapi/deployment.yaml
+++ b/charts/nebari-landing/templates/webapi/deployment.yaml
@@ -99,6 +99,10 @@ spec:
             # Health
             - name: HEALTH_INTERVAL
               value: {{ .Values.webapi.healthInterval | quote }}
+            {{- if .Values.webapi.healthProber.enabled }}
+            - name: HEALTH_PROBE_RUNNER_URL
+              value: {{ printf "http://%s-health-prober.%s.svc.cluster.local:%v" (include "nebari-landing.fullname" .) .Release.Namespace .Values.webapi.healthProber.service.port | quote }}
+            {{- end }}
             # Redis
             - name: REDIS_ADDR
               value: {{ include "nebari-landing.redisAddr" . | quote }}

--- a/charts/nebari-landing/templates/webapi/healthprober-deployment.yaml
+++ b/charts/nebari-landing/templates/webapi/healthprober-deployment.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.webapi.healthProber.enabled }}
+{{- if ne (int .Values.webapi.healthProber.service.port) (int .Values.webapi.healthProber.port) }}
+{{- fail "webapi.healthProber.service.port must match webapi.healthProber.port" }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "nebari-landing.fullname" . }}-health-prober
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "nebari-landing.labels" . | nindent 4 }}
+    app.kubernetes.io/component: health-prober
+spec:
+  replicas: {{ .Values.webapi.healthProber.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "nebari-landing.healthProber.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "nebari-landing.labels" . | nindent 8 }}
+        {{- include "nebari-landing.healthProber.selectorLabels" . | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: health-prober
+          image: "{{ .Values.webapi.image.repository }}:{{ .Values.webapi.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.webapi.image.pullPolicy }}
+          args:
+            - --probe-runner
+          ports:
+            - name: http
+              containerPort: {{ .Values.webapi.healthProber.port }}
+              protocol: TCP
+          env:
+            - name: PORT
+              value: {{ .Values.webapi.healthProber.port | quote }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.webapi.healthProber.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.webapi.healthProber.port }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.webapi.healthProber.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+      terminationGracePeriodSeconds: 10
+{{- end }}

--- a/charts/nebari-landing/templates/webapi/healthprober-networkpolicy.yaml
+++ b/charts/nebari-landing/templates/webapi/healthprober-networkpolicy.yaml
@@ -1,0 +1,94 @@
+{{- if and .Values.webapi.healthProber.enabled .Values.webapi.healthProber.networkPolicy.enabled }}
+{{- $egress := .Values.webapi.healthProber.networkPolicy.egress }}
+{{- $protectedNamespaces := list "argocd" "cert-manager" "database" "databases" "db" "envoy-gateway-system" "kube-node-lease" "kube-public" "kube-system" "keycloak" "mariadb" "metallb-system" "mongo" "mongodb" "mysql" "postgres" "postgresql" "redis" "vault" }}
+{{- $protectedPorts := list 2181 2379 2380 3306 5432 6379 6443 9200 9300 10250 10255 11211 27017 27018 27019 }}
+{{- if and $egress.sameNamespaceHealthChecks.enabled (empty $egress.sameNamespaceHealthChecks.namespaceSelector) }}
+{{- fail "webapi.healthProber.networkPolicy.egress.sameNamespaceHealthChecks.namespaceSelector must be non-empty when health-check egress is enabled" }}
+{{- end }}
+{{- if $egress.sameNamespaceHealthChecks.enabled }}
+{{- $excludesProtectedNamespaces := false }}
+{{- range $expr := $egress.sameNamespaceHealthChecks.namespaceSelector.matchExpressions }}
+{{- if and (eq $expr.key "kubernetes.io/metadata.name") (eq $expr.operator "NotIn") }}
+{{- $missing := list }}
+{{- range $protectedNamespaces }}
+{{- if not (has . $expr.values) }}
+{{- $missing = append $missing . }}
+{{- end }}
+{{- end }}
+{{- if empty $missing }}
+{{- $excludesProtectedNamespaces = true }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if not $excludesProtectedNamespaces }}
+{{- fail "webapi.healthProber.networkPolicy.egress.sameNamespaceHealthChecks.namespaceSelector must exclude protected namespaces" }}
+{{- end }}
+{{- range $port := $egress.sameNamespaceHealthChecks.ports }}
+{{- if has (int $port) $protectedPorts }}
+{{- fail (printf "webapi.healthProber.networkPolicy.egress.sameNamespaceHealthChecks.ports must not include protected port %v" $port) }}
+{{- end }}
+{{- end }}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "nebari-landing.fullname" . }}-health-prober
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "nebari-landing.labels" . | nindent 4 }}
+    app.kubernetes.io/component: health-prober
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "nebari-landing.healthProber.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "nebari-landing.webapi.selectorLabels" . | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.webapi.healthProber.port }}
+  egress:
+    {{- if $egress.dns.enabled }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              {{- toYaml $egress.dns.namespaceSelector | nindent 14 }}
+          {{- if $egress.dns.podSelector }}
+          podSelector:
+            matchLabels:
+              {{- toYaml $egress.dns.podSelector | nindent 14 }}
+          {{- else }}
+          podSelector: {}
+          {{- end }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+    {{- if and $egress.sameNamespaceHealthChecks.enabled $egress.sameNamespaceHealthChecks.ports }}
+    - to:
+        - namespaceSelector:
+            {{- toYaml $egress.sameNamespaceHealthChecks.namespaceSelector | nindent 12 }}
+          {{- if $egress.sameNamespaceHealthChecks.podSelector }}
+          podSelector:
+            matchLabels:
+              {{- toYaml $egress.sameNamespaceHealthChecks.podSelector | nindent 14 }}
+          {{- else }}
+          podSelector: {}
+          {{- end }}
+      ports:
+        {{- range $egress.sameNamespaceHealthChecks.ports }}
+        - protocol: TCP
+          port: {{ . }}
+        {{- end }}
+    {{- end }}
+    {{- with $egress.additionalRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/nebari-landing/templates/webapi/healthprober-service.yaml
+++ b/charts/nebari-landing/templates/webapi/healthprober-service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.webapi.healthProber.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nebari-landing.fullname" . }}-health-prober
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "nebari-landing.labels" . | nindent 4 }}
+    app.kubernetes.io/component: health-prober
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ .Values.webapi.healthProber.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "nebari-landing.healthProber.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/nebari-landing/templates/webapi/networkpolicy.yaml
+++ b/charts/nebari-landing/templates/webapi/networkpolicy.yaml
@@ -1,0 +1,101 @@
+{{- if .Values.webapi.networkPolicy.enabled }}
+{{- $egress := .Values.webapi.networkPolicy.egress }}
+{{- if and $egress.keycloak.enabled (empty $egress.keycloak.namespaceSelector) }}
+{{- fail "webapi.networkPolicy.egress.keycloak.namespaceSelector must be non-empty when keycloak egress is enabled" }}
+{{- end }}
+{{- if and $egress.keycloak.enabled (empty $egress.keycloak.podSelector) }}
+{{- fail "webapi.networkPolicy.egress.keycloak.podSelector must be non-empty when keycloak egress is enabled" }}
+{{- end }}
+{{- $apiCIDRs := list }}
+{{- range $egress.kubernetesAPI.cidrs }}
+{{- $apiCIDRs = append $apiCIDRs . }}
+{{- end }}
+{{- if and (empty $apiCIDRs) $egress.kubernetesAPI.lookup.enabled }}
+{{- $apiService := lookup "v1" "Service" $egress.kubernetesAPI.lookup.namespace $egress.kubernetesAPI.lookup.serviceName }}
+{{- $clusterIP := "" }}
+{{- if $apiService }}
+{{- $clusterIP = dig "spec" "clusterIP" "" $apiService }}
+{{- end }}
+{{- if and $clusterIP (ne $clusterIP "None") }}
+{{- $apiCIDRs = append $apiCIDRs (printf "%s/32" $clusterIP) }}
+{{- end }}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "nebari-landing.fullname" . }}-webapi-egress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "nebari-landing.labels" . | nindent 4 }}
+    app.kubernetes.io/component: webapi
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "nebari-landing.webapi.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Egress
+  egress:
+    {{- if $egress.dns.enabled }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              {{- toYaml $egress.dns.namespaceSelector | nindent 14 }}
+          {{- if $egress.dns.podSelector }}
+          podSelector:
+            matchLabels:
+              {{- toYaml $egress.dns.podSelector | nindent 14 }}
+          {{- else }}
+          podSelector: {}
+          {{- end }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+    {{- if $egress.redis.enabled }}
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: redis
+              app.kubernetes.io/instance: {{ .Release.Name }}
+              app.kubernetes.io/component: master
+      ports:
+        - protocol: TCP
+          port: 6379
+    {{- end }}
+    {{- if and $egress.keycloak.enabled $egress.keycloak.ports }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              {{- toYaml $egress.keycloak.namespaceSelector | nindent 14 }}
+          podSelector:
+            matchLabels:
+              {{- toYaml $egress.keycloak.podSelector | nindent 14 }}
+      ports:
+        {{- range $egress.keycloak.ports }}
+        - protocol: TCP
+          port: {{ . }}
+        {{- end }}
+    {{- end }}
+    {{- range $apiCIDRs }}
+    - to:
+        - ipBlock:
+            cidr: {{ . | quote }}
+      ports:
+        - protocol: TCP
+          port: {{ $egress.kubernetesAPI.port }}
+    {{- end }}
+    {{- if .Values.webapi.healthProber.enabled }}
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "nebari-landing.healthProber.selectorLabels" . | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.webapi.healthProber.port }}
+    {{- end }}
+    {{- with $egress.additionalRules }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/nebari-landing/templates/webapi/rbac.yaml
+++ b/charts/nebari-landing/templates/webapi/rbac.yaml
@@ -11,6 +11,9 @@ rules:
   - apiGroups: ["reconcilers.nebari.dev"]
     resources: ["nebariapps"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["referencegrants"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/nebari-landing/tests/assert-resource-defaults.rb
+++ b/charts/nebari-landing/tests/assert-resource-defaults.rb
@@ -22,6 +22,15 @@ EXPECTED_RESOURCES = {
       "limits" => { "cpu" => "200m", "memory" => "128Mi" }
     }
   },
+  "health-prober Deployment" => {
+    kind: "Deployment",
+    labels: { "app.kubernetes.io/component" => "health-prober" },
+    container: "health-prober",
+    resources: {
+      "requests" => { "cpu" => "10m", "memory" => "32Mi" },
+      "limits" => { "cpu" => "100m", "memory" => "64Mi" }
+    }
+  },
   "redis master StatefulSet" => {
     kind: "StatefulSet",
     labels: {
@@ -36,6 +45,15 @@ EXPECTED_RESOURCES = {
   }
 }.freeze
 
+EXPECTED_WEBAPI_EGRESS_PORTS = [53, 6379, 8080, 8443, 8081].freeze
+EXPECTED_HEALTH_CHECK_PORTS = [80, 8080].freeze
+DENIED_SAME_NAMESPACE_PORTS = [2379, 2380, 3306, 5432, 6379, 6443, 10250, 10255].freeze
+PROTECTED_HEALTH_NAMESPACES = %w[
+  kube-system kube-public kube-node-lease keycloak argocd cert-manager
+  envoy-gateway-system metallb-system database databases db redis postgres
+  postgresql mysql mariadb mongodb mongo vault
+].freeze
+
 def labels_match?(manifest, expected_labels)
   labels = manifest.dig("metadata", "labels") || {}
   expected_labels.all? { |key, value| labels[key] == value }
@@ -43,6 +61,116 @@ end
 
 def pod_containers(manifest)
   manifest.dig("spec", "template", "spec", "containers") || []
+end
+
+def webapi_egress_policy(manifests)
+  egress_policy_for(manifests, "webapi")
+end
+
+def health_prober_policy(manifests)
+  egress_policy_for(manifests, "health-prober")
+end
+
+def egress_policy_for(manifests, component)
+  manifests.find do |doc|
+    doc["kind"] == "NetworkPolicy" &&
+      labels_match?(doc, { "app.kubernetes.io/component" => component }) &&
+      Array(doc.dig("spec", "policyTypes")).include?("Egress")
+  end
+end
+
+def egress_ports(policy)
+  Array(policy.dig("spec", "egress")).flat_map do |rule|
+    Array(rule["ports"]).map { |entry| entry["port"] }
+  end
+end
+
+def empty_pod_selector?(selector)
+  selector.nil? || selector == {} || selector == { "matchLabels" => {} }
+end
+
+def hardcodes_default_api_server_cidr?(policy)
+  Array(policy.dig("spec", "egress")).any? do |rule|
+    Array(rule["to"]).any? do |target|
+      target.dig("ipBlock", "cidr") == "10.96.0.1/32"
+    end
+  end
+end
+
+def keycloak_allow_is_namespace_wide?(policy)
+  Array(policy.dig("spec", "egress")).any? do |rule|
+    Array(rule["to"]).any? do |target|
+      target.dig("namespaceSelector", "matchLabels", "kubernetes.io/metadata.name") == "keycloak" &&
+        empty_pod_selector?(target["podSelector"])
+    end
+  end
+end
+
+def same_namespace_wildcard_ports(policy)
+  Array(policy.dig("spec", "egress")).flat_map do |rule|
+    wildcard_target = Array(rule["to"]).any? do |target|
+      target["namespaceSelector"].nil? &&
+        target["ipBlock"].nil? &&
+        empty_pod_selector?(target["podSelector"])
+    end
+    wildcard_target ? Array(rule["ports"]).map { |entry| entry["port"] } : []
+  end
+end
+
+def health_check_namespace_selector?(selector)
+  Array(selector && selector["matchExpressions"]).any? do |expression|
+    expression["key"] == "kubernetes.io/metadata.name" &&
+      expression["operator"] == "NotIn" &&
+      (PROTECTED_HEALTH_NAMESPACES - Array(expression["values"])).empty?
+  end
+end
+
+def health_check_ports(policy)
+  Array(policy.dig("spec", "egress")).flat_map do |rule|
+    health_target = Array(rule["to"]).any? do |target|
+      health_check_namespace_selector?(target["namespaceSelector"]) &&
+        empty_pod_selector?(target["podSelector"])
+    end
+    health_target ? Array(rule["ports"]).map { |entry| entry["port"] } : []
+  end
+end
+
+def has_same_namespace_health_allow?(policy)
+  (EXPECTED_HEALTH_CHECK_PORTS - health_check_ports(policy)).empty?
+end
+
+def has_denied_same_namespace_ports?(policy)
+  !(DENIED_SAME_NAMESPACE_PORTS & health_check_ports(policy)).empty?
+end
+
+def has_release_namespace_only_health_allow?(policy)
+  (EXPECTED_HEALTH_CHECK_PORTS - same_namespace_wildcard_ports(policy)).empty?
+end
+
+def has_api_server_allow?(policy, cidr)
+  Array(policy.dig("spec", "egress")).any? do |rule|
+    Array(rule["to"]).any? do |target|
+      target.dig("ipBlock", "cidr") == cidr
+    end && Array(rule["ports"]).any? { |entry| entry["protocol"] == "TCP" && entry["port"] == 443 }
+  end
+end
+
+def has_component_allow?(policy, direction, component, port)
+  Array(policy.dig("spec", direction)).any? do |rule|
+    Array(rule[direction == "egress" ? "to" : "from"]).any? do |target|
+      target.dig("podSelector", "matchLabels", "app.kubernetes.io/component") == component
+    end && Array(rule["ports"]).any? { |entry| entry["protocol"] == "TCP" && entry["port"] == port }
+  end
+end
+
+def has_sensitive_dependency_egress?(policy)
+  Array(policy.dig("spec", "egress")).any? do |rule|
+    Array(rule["to"]).any? do |target|
+      target.dig("podSelector", "matchLabels", "app.kubernetes.io/name") == "redis" ||
+        target.dig("namespaceSelector", "matchLabels", "kubernetes.io/metadata.name") == "keycloak" ||
+        target.key?("ipBlock")
+    end
+  end
 end
 
 manifests = YAML.load_stream(ARGF.read).compact.select { |doc| doc.is_a?(Hash) }
@@ -67,6 +195,72 @@ EXPECTED_RESOURCES.each do |name, expected|
   next if container["resources"] == expected[:resources]
 
   failures << "#{name} resources were #{container['resources'].inspect}, expected #{expected[:resources].inspect}"
+end
+
+webapi_policy = webapi_egress_policy(manifests)
+if webapi_policy.nil?
+  failures << "Missing default webapi egress NetworkPolicy"
+else
+  if hardcodes_default_api_server_cidr?(webapi_policy)
+    failures << "webapi egress NetworkPolicy hard-codes the Kubernetes API ClusterIP"
+  end
+
+  if keycloak_allow_is_namespace_wide?(webapi_policy)
+    failures << "webapi egress NetworkPolicy allows the whole Keycloak namespace"
+  end
+
+  if has_same_namespace_health_allow?(webapi_policy)
+    failures << "webapi egress NetworkPolicy enables health-check egress by default"
+  end
+
+  if has_denied_same_namespace_ports?(webapi_policy)
+    failures << "webapi egress NetworkPolicy allows denied same-namespace infrastructure ports"
+  end
+
+  if has_release_namespace_only_health_allow?(webapi_policy)
+    failures << "webapi egress NetworkPolicy scopes health checks only to the release namespace"
+  end
+
+  unless has_component_allow?(webapi_policy, "egress", "health-prober", 8081)
+    failures << "webapi egress NetworkPolicy does not route health probes through the health-prober"
+  end
+
+  expected_ports = EXPECTED_WEBAPI_EGRESS_PORTS.dup
+  expected_ports << 443 if ENV["EXPECTED_WEBAPI_API_CIDR"]
+  missing_ports = expected_ports - egress_ports(webapi_policy)
+  unless missing_ports.empty?
+    failures << "webapi egress NetworkPolicy is missing expected ports #{missing_ports.inspect}"
+  end
+
+  expected_api_cidr = ENV["EXPECTED_WEBAPI_API_CIDR"]
+  if expected_api_cidr && !has_api_server_allow?(webapi_policy, expected_api_cidr)
+    failures << "webapi egress NetworkPolicy is missing Kubernetes API allow for #{expected_api_cidr}"
+  end
+end
+
+health_policy = health_prober_policy(manifests)
+if health_policy.nil?
+  failures << "Missing default health-prober NetworkPolicy"
+else
+  if has_sensitive_dependency_egress?(health_policy)
+    failures << "health-prober NetworkPolicy allows sensitive webapi dependency egress"
+  end
+
+  unless has_component_allow?(health_policy, "ingress", "webapi", 8081)
+    failures << "health-prober NetworkPolicy does not restrict ingress to the webapi"
+  end
+
+  unless has_same_namespace_health_allow?(health_policy)
+    failures << "health-prober NetworkPolicy is missing constrained health-check egress"
+  end
+
+  if has_denied_same_namespace_ports?(health_policy)
+    failures << "health-prober NetworkPolicy allows denied health-check infrastructure ports"
+  end
+
+  if has_release_namespace_only_health_allow?(health_policy)
+    failures << "health-prober NetworkPolicy scopes health checks only to the release namespace"
+  end
 end
 
 abort failures.join("\n") unless failures.empty?

--- a/charts/nebari-landing/values.yaml
+++ b/charts/nebari-landing/values.yaml
@@ -157,6 +157,69 @@ webapi:
 
   healthInterval: 30
 
+  # Isolated health probe runner. The webapi delegates NebariApp-driven HTTP
+  # probes to this pod so probe egress can be constrained separately from the
+  # webapi's required Redis, Keycloak, and Kubernetes API traffic.
+  healthProber:
+    enabled: true
+    replicaCount: 1
+    port: 8081
+    service:
+      port: 8081
+    resources:
+      requests:
+        cpu: 10m
+        memory: 32Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
+    networkPolicy:
+      enabled: true
+      egress:
+        dns:
+          enabled: true
+          namespaceSelector:
+            kubernetes.io/metadata.name: kube-system
+          podSelector:
+            k8s-app: kube-dns
+        # Health checks are app-side constrained to the declared backend and
+        # require Gateway API ReferenceGrant consent for cross-namespace targets.
+        # This runner policy is the only default health-target egress path; it
+        # must exclude metadata, control-plane, database, and identity classes.
+        sameNamespaceHealthChecks:
+          enabled: true
+          namespaceSelector:
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: NotIn
+                values:
+                  - kube-system
+                  - kube-public
+                  - kube-node-lease
+                  - keycloak
+                  - argocd
+                  - cert-manager
+                  - envoy-gateway-system
+                  - metallb-system
+                  - database
+                  - databases
+                  - db
+                  - redis
+                  - postgres
+                  - postgresql
+                  - mysql
+                  - mariadb
+                  - mongodb
+                  - mongo
+                  - vault
+          podSelector: {}
+          ports:
+            - 80
+            - 8080
+        # Extra raw NetworkPolicy egress rules for approved consented
+        # cross-namespace health targets or non-standard service ports.
+        additionalRules: []
+
   # Automatic platform notifications — require Redis (notifications.enabled implies redis.enabled).
   notifications:
     # Post a welcome/feedback notification every time the webapi starts.
@@ -189,6 +252,57 @@ webapi:
   service:
     type: ClusterIP
     port: 8080
+
+  # Egress NetworkPolicy for the webapi pod. Enabled by default so the webapi
+  # starts from default-deny egress plus the approved dependencies below.
+  # NebariApp-driven health probes do not use this egress path; they are
+  # delegated to webapi.healthProber so probe targets can be constrained with a
+  # separate NetworkPolicy.
+  # Kubernetes NetworkPolicy cannot portably infer the API server CIDR. Live
+  # Helm installs discover it with lookup(); GitOps/offline renderers must set
+  # kubernetesAPI.cidrs explicitly.
+  networkPolicy:
+    enabled: true
+    egress:
+      # Required for resolving in-cluster Service DNS names.
+      dns:
+        enabled: true
+        namespaceSelector:
+          kubernetes.io/metadata.name: kube-system
+        podSelector:
+          k8s-app: kube-dns
+
+      # Required when redis.enabled=true.
+      redis:
+        enabled: true
+
+      # Required when Keycloak JWT/JWKS/admin calls stay in-cluster. Keep this
+      # selector narrow; the defaults match the keycloakx release used by NIC.
+      keycloak:
+        enabled: true
+        namespaceSelector:
+          kubernetes.io/metadata.name: keycloak
+        podSelector:
+          app.kubernetes.io/name: keycloakx
+          app.kubernetes.io/instance: keycloak
+        ports:
+          - 8080
+          - 8443
+
+      # Required for watching NebariApps. Standard NetworkPolicy cannot select
+      # the kubernetes.default Service directly, so live Helm installs discover
+      # its ClusterIP with lookup(). GitOps/offline renderers should set cidrs
+      # explicitly to the approved API-server Service IP/CIDR.
+      kubernetesAPI:
+        port: 443
+        lookup:
+          enabled: true
+          namespace: default
+          serviceName: kubernetes
+        cidrs: []
+
+      # Extra raw NetworkPolicy egress rules for approved webapi dependencies.
+      additionalRules: []
 
 # ---------------------------------------------------------------------------
 # NebariApp CRs  (recommended on a full Nebari / nebari-operator deployment)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -72,6 +72,12 @@ func init() {
 	nebariGV := schema.GroupVersion{Group: "reconcilers.nebari.dev", Version: "v1"}
 	scheme.AddKnownTypeWithName(nebariGV.WithKind("NebariApp"), &unstructured.Unstructured{})
 	scheme.AddKnownTypeWithName(nebariGV.WithKind("NebariAppList"), &unstructured.UnstructuredList{})
+
+	// Register Gateway API ReferenceGrant as unstructured. The watcher uses it
+	// as target-namespace consent for cross-namespace health-check probes.
+	gatewayGV := schema.GroupVersion{Group: "gateway.networking.k8s.io", Version: "v1beta1"}
+	scheme.AddKnownTypeWithName(gatewayGV.WithKind("ReferenceGrant"), &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(gatewayGV.WithKind("ReferenceGrantList"), &unstructured.UnstructuredList{})
 }
 
 func main() {
@@ -92,6 +98,8 @@ func main() {
 		notifLifecycle bool
 		notifRetention time.Duration
 		enableDocs     bool
+		probeRunner    bool
+		probeRunnerURL string
 	)
 
 	// Flags fall back to environment variables so the binary works naturally when
@@ -130,6 +138,10 @@ func main() {
 		"How long notifications remain in Redis before expiring, e.g. 72h (env: NOTIFICATIONS_RETENTION)")
 	flag.BoolVar(&enableDocs, "enable-docs", envBool("ENABLE_DOCS", false),
 		"Expose the OpenAPI spec at /api/v1/docs/openapi.json and a Scalar viewer at /api/v1/docs. Never enable in production (env: ENABLE_DOCS)")
+	flag.BoolVar(&probeRunner, "probe-runner", envBool("PROBE_RUNNER", false),
+		"Run only the isolated health-probe runner service (env: PROBE_RUNNER)")
+	flag.StringVar(&probeRunnerURL, "health-probe-runner-url", os.Getenv("HEALTH_PROBE_RUNNER_URL"),
+		"URL of the isolated health-probe runner service (env: HEALTH_PROBE_RUNNER_URL)")
 
 	opts := zap.Options{
 		Development: true,
@@ -151,6 +163,11 @@ func main() {
 		"notificationsStartup", notifStartup,
 		"notificationsLifecycle", notifLifecycle,
 	)
+
+	if probeRunner {
+		runProbeRunner(port)
+		return
+	}
 
 	config, err := ctrl.GetConfig()
 	if err != nil {
@@ -267,6 +284,13 @@ func main() {
 	}
 
 	healthChecker := health.NewHealthChecker(serviceCache, time.Duration(healthInterval)*time.Second)
+	if probeRunnerURL != "" {
+		if err := healthChecker.SetProbeRunnerURL(probeRunnerURL); err != nil {
+			setupLog.Error(err, "Invalid health probe runner URL")
+			os.Exit(1)
+		}
+		setupLog.Info("Health probes delegated to isolated runner", "url", probeRunnerURL)
+	}
 	healthChecker.SetPublisher(hub)
 	if notifLifecycle {
 		healthChecker.SetNotificationStore(notificationStore)
@@ -351,6 +375,35 @@ func main() {
 	}
 
 	setupLog.Info("Server stopped")
+}
+
+func runProbeRunner(port int) {
+	setupLog.Info("Starting isolated health probe runner", "port", port)
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	server := &http.Server{
+		Addr:         fmt.Sprintf(":%d", port),
+		Handler:      health.NewProbeRunnerHandler(),
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 40 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+
+	go func() {
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			setupLog.Error(err, "Health probe runner failed")
+			os.Exit(1)
+		}
+	}()
+
+	<-ctx.Done()
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		setupLog.Error(err, "Health probe runner shutdown failed")
+	}
 }
 
 // envStr returns the value of the named environment variable, or def if unset/empty.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -40,6 +40,11 @@ type App struct {
 	// ServicePort is spec.service.port — the port on the Kubernetes Service.
 	ServicePort int
 
+	// HealthCheckCrossNamespaceAllowed is true when the health-check target
+	// Service lives outside Namespace and that target namespace has explicitly
+	// granted this NebariApp namespace permission to reference the Service.
+	HealthCheckCrossNamespaceAllowed bool
+
 	// LandingPage holds the resolved landing-page configuration, or nil when
 	// the application does not participate in service discovery.
 	LandingPage *LandingPage
@@ -110,9 +115,9 @@ type HealthCheck struct {
 	// Defaults to 5 when not set.
 	TimeoutSeconds int
 
-	// Port overrides the service port for the health probe. Useful when the
-	// target exposes health endpoints on a separate management port (e.g.
-	// Keycloak X exposes /health/ready on port 9000, not the main 8080).
+	// Port mirrors spec.landingPage.healthCheck.port when present. It is
+	// accepted only when it matches spec.service.port; otherwise the health check
+	// is disabled so app authors cannot widen probes to arbitrary ports.
 	// When 0, spec.service.port is used.
 	Port int
 }

--- a/internal/cache/service_cache.go
+++ b/internal/cache/service_cache.go
@@ -2,12 +2,85 @@ package cache
 
 import (
 	"fmt"
+	"net/url"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
 	sdapp "github.com/nebari-dev/nebari-landing/internal/app"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
+
+const (
+	defaultHealthCheckIntervalSeconds = 30
+	minHealthCheckIntervalSeconds     = 10
+	maxHealthCheckIntervalSeconds     = 300
+
+	defaultHealthCheckTimeoutSeconds = 5
+	minHealthCheckTimeoutSeconds     = 1
+	maxHealthCheckTimeoutSeconds     = 30
+
+	maxHealthCheckPathLength = 2048
+)
+
+var protectedHealthCheckNamespaces = map[string]struct{}{
+	"argocd":               {},
+	"cert-manager":         {},
+	"database":             {},
+	"databases":            {},
+	"db":                   {},
+	"envoy-gateway-system": {},
+	"kube-node-lease":      {},
+	"kube-public":          {},
+	"kube-system":          {},
+	"keycloak":             {},
+	"mariadb":              {},
+	"metallb-system":       {},
+	"mongo":                {},
+	"mongodb":              {},
+	"mysql":                {},
+	"postgres":             {},
+	"postgresql":           {},
+	"redis":                {},
+	"vault":                {},
+}
+
+var protectedHealthCheckServiceTokens = map[string]struct{}{
+	"coredns":    {},
+	"dns":        {},
+	"etcd":       {},
+	"keycloak":   {},
+	"kube":       {},
+	"kubernetes": {},
+	"mariadb":    {},
+	"metadata":   {},
+	"mongo":      {},
+	"mongodb":    {},
+	"mysql":      {},
+	"postgres":   {},
+	"postgresql": {},
+	"redis":      {},
+	"vault":      {},
+}
+
+var protectedHealthCheckPorts = map[int]struct{}{
+	2181:  {},
+	2379:  {},
+	2380:  {},
+	3306:  {},
+	5432:  {},
+	6379:  {},
+	6443:  {},
+	9200:  {},
+	9300:  {},
+	10250: {},
+	10255: {},
+	11211: {},
+	27017: {},
+	27018: {},
+	27019: {},
+}
 
 // ServiceInfo represents a service that appears on the landing page
 type ServiceInfo struct {
@@ -90,6 +163,15 @@ func (c *ServiceCache) Add(a *sdapp.App) {
 	if lp.Visibility != "" {
 		visibility = lp.Visibility
 	}
+	healthCheckConfig := buildHealthCheckConfig(a)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	health := c.preserveHealthStatus(a.UID)
+	if c.shouldResetHealthStatus(a.UID, healthCheckConfig) {
+		health = &HealthStatus{Status: "unknown"}
+	}
 
 	service := &ServiceInfo{
 		UID:               a.UID,
@@ -105,12 +187,10 @@ func (c *ServiceCache) Add(a *sdapp.App) {
 		Priority:          priority,
 		Visibility:        visibility,
 		RequiredGroups:    lp.RequiredGroups,
-		Health:            c.preserveHealthStatus(a.UID),
-		HealthCheckConfig: buildHealthCheckConfig(a),
+		Health:            health,
+		HealthCheckConfig: healthCheckConfig,
 	}
 
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	c.services[a.UID] = service
 }
 
@@ -191,6 +271,36 @@ func (c *ServiceCache) UpdateHealth(uid string, status *HealthStatus) {
 	}
 }
 
+// WithCurrentHealthCheck runs fn only while uid still has cfg as its active
+// health-check configuration. The read lock is held for fn so writers that
+// remove or replace cfg cannot interleave between the freshness check and the
+// protected operation.
+func (c *ServiceCache) ,(uid string, cfg *HealthCheckConfig, fn func(prevStatus string)) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	service := c.services[uid]
+	if service == nil || service.HealthCheckConfig == nil || cfg == nil || *service.HealthCheckConfig != *cfg {
+		return false
+	}
+	prevStatus := ""
+	if service.Health != nil {
+		prevStatus = service.Health.Status
+	}
+	fn(prevStatus)
+	return true
+}
+
+// HealthCheckConfigCurrent reports whether uid still has cfg as its active
+// health-check configuration.
+func (c *ServiceCache) HealthCheckConfigCurrent(uid string, cfg *HealthCheckConfig) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	service := c.services[uid]
+	return service != nil && service.HealthCheckConfig != nil && cfg != nil && *service.HealthCheckConfig == *cfg
+}
+
 func (c *ServiceCache) preserveHealthStatus(uid string) *HealthStatus {
 	if existing := c.services[uid]; existing != nil && existing.Health != nil {
 		return existing.Health
@@ -198,6 +308,11 @@ func (c *ServiceCache) preserveHealthStatus(uid string) *HealthStatus {
 	return &HealthStatus{
 		Status: "unknown",
 	}
+}
+
+func (c *ServiceCache) shouldResetHealthStatus(uid string, cfg *HealthCheckConfig) bool {
+	existing := c.services[uid]
+	return existing != nil && existing.HealthCheckConfig != nil && cfg == nil
 }
 
 func buildURL(a *sdapp.App) string {
@@ -219,18 +334,27 @@ func buildHealthCheckConfig(a *sdapp.App) *HealthCheckConfig {
 		return nil
 	}
 	hc := a.LandingPage.HealthCheck
-	path := hc.Path
-	if path == "" {
-		path = "/"
+	path, ok := normalizeHealthCheckPath(hc.Path)
+	if !ok {
+		return nil
 	}
-	interval := hc.IntervalSeconds
-	if interval <= 0 {
-		interval = 30
+
+	interval := clampHealthCheckSeconds(
+		hc.IntervalSeconds,
+		defaultHealthCheckIntervalSeconds,
+		minHealthCheckIntervalSeconds,
+		maxHealthCheckIntervalSeconds,
+	)
+	timeout := clampHealthCheckSeconds(
+		hc.TimeoutSeconds,
+		defaultHealthCheckTimeoutSeconds,
+		minHealthCheckTimeoutSeconds,
+		maxHealthCheckTimeoutSeconds,
+	)
+	if timeout > interval {
+		timeout = interval
 	}
-	timeout := hc.TimeoutSeconds
-	if timeout <= 0 {
-		timeout = 5
-	}
+
 	// Probe the Kubernetes service directly using in-cluster DNS so the health
 	// check bypasses the ingress/gateway and always uses HTTP regardless of
 	// whether TLS is configured for external access.
@@ -238,26 +362,99 @@ func buildHealthCheckConfig(a *sdapp.App) *HealthCheckConfig {
 	if serviceName == "" {
 		serviceName = a.Name
 	}
+	if len(validation.IsDNS1035Label(serviceName)) != 0 {
+		return nil
+	}
 	servicePort := a.ServicePort
 	if servicePort == 0 {
 		servicePort = 80
 	}
-	// Allow healthCheck.port to override the service port for services that
-	// expose health endpoints on a separate management port (e.g. Keycloak X
-	// management port 9000 vs main HTTP port 8080).
-	if hc.Port > 0 {
-		servicePort = hc.Port
+	// healthCheck.port is not allowed to widen the target beyond the declared
+	// backend Service port; otherwise a NebariApp author could probe arbitrary
+	// ports on an otherwise legitimate Service.
+	if hc.Port > 0 && hc.Port != servicePort {
+		return nil
 	}
-	// Use ServiceNamespace (spec.service.namespace) so cross-namespace services
-	// (e.g. Keycloak in 'keycloak', ArgoCD in 'argocd') are probed via the
-	// correct in-cluster DNS name rather than the NebariApp's own namespace.
+	if servicePort < 1 || servicePort > 65535 {
+		return nil
+	}
+	// Use ServiceNamespace (spec.service.namespace) only after enforcing the
+	// cross-namespace consent decision made by the watcher.
 	serviceNamespace := a.ServiceNamespace
 	if serviceNamespace == "" {
 		serviceNamespace = a.Namespace
+	}
+	if len(validation.IsDNS1123Label(serviceNamespace)) != 0 {
+		return nil
+	}
+	if serviceNamespace != a.Namespace && !a.HealthCheckCrossNamespaceAllowed {
+		return nil
+	}
+	if HealthCheckTargetProtected(serviceNamespace, serviceName, servicePort) {
+		return nil
 	}
 	return &HealthCheckConfig{
 		ProbeURL:        fmt.Sprintf("http://%s.%s:%d%s", serviceName, serviceNamespace, servicePort, path),
 		IntervalSeconds: interval,
 		TimeoutSeconds:  timeout,
 	}
+}
+
+func normalizeHealthCheckPath(path string) (string, bool) {
+	if path == "" {
+		return "/", true
+	}
+	if len(path) > maxHealthCheckPathLength {
+		return "", false
+	}
+	if !strings.HasPrefix(path, "/") || strings.HasPrefix(path, "//") {
+		return "", false
+	}
+	for _, r := range path {
+		if r < 0x20 || r == 0x7f {
+			return "", false
+		}
+	}
+	parsed, err := url.ParseRequestURI(path)
+	if err != nil {
+		return "", false
+	}
+	if parsed.Scheme != "" || parsed.Host != "" || !strings.HasPrefix(parsed.Path, "/") {
+		return "", false
+	}
+	return path, true
+}
+
+func clampHealthCheckSeconds(value, defaultValue, minValue, maxValue int) int {
+	if value <= 0 {
+		return defaultValue
+	}
+	if value < minValue {
+		return minValue
+	}
+	if value > maxValue {
+		return maxValue
+	}
+	return value
+}
+
+// HealthCheckTargetProtected reports whether a health probe target is in a
+// namespace/service/port class that must not be reachable from NebariApp-owned
+// health checks.
+func HealthCheckTargetProtected(namespace, serviceName string, port int) bool {
+	if _, ok := protectedHealthCheckNamespaces[namespace]; ok {
+		return true
+	}
+	if strings.HasSuffix(namespace, "-system") {
+		return true
+	}
+	if _, ok := protectedHealthCheckPorts[port]; ok {
+		return true
+	}
+	for _, token := range strings.Split(serviceName, "-") {
+		if _, ok := protectedHealthCheckServiceTokens[token]; ok {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/cache/service_cache.go
+++ b/internal/cache/service_cache.go
@@ -275,7 +275,7 @@ func (c *ServiceCache) UpdateHealth(uid string, status *HealthStatus) {
 // health-check configuration. The read lock is held for fn so writers that
 // remove or replace cfg cannot interleave between the freshness check and the
 // protected operation.
-func (c *ServiceCache) ,(uid string, cfg *HealthCheckConfig, fn func(prevStatus string)) bool {
+func (c *ServiceCache) WithCurrentHealthCheck(uid string, cfg *HealthCheckConfig, fn func(prevStatus string)) bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 

--- a/internal/cache/service_cache_test.go
+++ b/internal/cache/service_cache_test.go
@@ -4,6 +4,7 @@
 package cache
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -265,5 +266,383 @@ func TestGetByNamespacedName_NotFound(t *testing.T) {
 	c := NewServiceCache()
 	if svc := c.GetByNamespacedName("ns", "missing"); svc != nil {
 		t.Errorf("expected nil, got %+v", svc)
+	}
+}
+
+func TestBuildHealthCheckConfig_UsesDeclaredSameNamespaceBackend(t *testing.T) {
+	c := NewServiceCache()
+	a := makeApp("uid-hc", "app", "team-a", "app.example.com", &sdapp.LandingPage{
+		Enabled: true,
+		HealthCheck: &sdapp.HealthCheck{
+			Enabled:         true,
+			Path:            "/ready?full=1",
+			IntervalSeconds: 60,
+			TimeoutSeconds:  7,
+		},
+	})
+	a.ServiceName = "app-backend"
+	a.ServicePort = 8080
+
+	c.Add(a)
+
+	svc := c.Get("uid-hc")
+	if svc == nil || svc.HealthCheckConfig == nil {
+		t.Fatalf("expected health check config, got %+v", svc)
+	}
+	if got, want := svc.HealthCheckConfig.ProbeURL, "http://app-backend.team-a:8080/ready?full=1"; got != want {
+		t.Errorf("ProbeURL = %q, want %q", got, want)
+	}
+}
+
+func TestBuildHealthCheckConfig_DeniesCrossNamespaceByDefault(t *testing.T) {
+	c := NewServiceCache()
+	a := makeApp("uid-cross", "app", "team-a", "app.example.com", &sdapp.LandingPage{
+		Enabled: true,
+		HealthCheck: &sdapp.HealthCheck{
+			Enabled: true,
+			Path:    "/ready",
+		},
+	})
+	a.ServiceName = "shared-api"
+	a.ServiceNamespace = "platform"
+	a.ServicePort = 8080
+
+	c.Add(a)
+
+	svc := c.Get("uid-cross")
+	if svc == nil {
+		t.Fatal("expected service in cache")
+	}
+	if svc.HealthCheckConfig != nil {
+		t.Fatalf("expected cross-namespace health check to be denied, got %+v", svc.HealthCheckConfig)
+	}
+}
+
+func TestBuildHealthCheckConfig_AllowsConsentedCrossNamespaceTarget(t *testing.T) {
+	c := NewServiceCache()
+	a := makeApp("uid-cross-ok", "app", "team-a", "app.example.com", &sdapp.LandingPage{
+		Enabled: true,
+		HealthCheck: &sdapp.HealthCheck{
+			Enabled: true,
+			Path:    "/ready",
+		},
+	})
+	a.ServiceName = "shared-api"
+	a.ServiceNamespace = "platform"
+	a.ServicePort = 8080
+	a.HealthCheckCrossNamespaceAllowed = true
+
+	c.Add(a)
+
+	svc := c.Get("uid-cross-ok")
+	if svc == nil || svc.HealthCheckConfig == nil {
+		t.Fatalf("expected health check config, got %+v", svc)
+	}
+	if got, want := svc.HealthCheckConfig.ProbeURL, "http://shared-api.platform:8080/ready"; got != want {
+		t.Errorf("ProbeURL = %q, want %q", got, want)
+	}
+}
+
+func TestBuildHealthCheckConfig_RejectsInvalidPath(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		path string
+	}{
+		{name: "relative", path: "ready"},
+		{name: "authority", path: "//metadata.internal/latest"},
+		{name: "bad escape", path: "/bad%zz"},
+		{name: "control character", path: "/bad\nheader"},
+		{name: "too long", path: "/" + strings.Repeat("a", maxHealthCheckPathLength)},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewServiceCache()
+			c.Add(makeApp("uid-path", "app", "ns", "app.example.com", &sdapp.LandingPage{
+				Enabled: true,
+				HealthCheck: &sdapp.HealthCheck{
+					Enabled: true,
+					Path:    tt.path,
+				},
+			}))
+
+			svc := c.Get("uid-path")
+			if svc == nil {
+				t.Fatal("expected service in cache")
+			}
+			if svc.HealthCheckConfig != nil {
+				t.Fatalf("expected invalid path %q to disable health check, got %+v", tt.path, svc.HealthCheckConfig)
+			}
+		})
+	}
+}
+
+func TestBuildHealthCheckConfig_ClampsIntervalAndTimeout(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		interval     int
+		timeout      int
+		wantInterval int
+		wantTimeout  int
+	}{
+		{
+			name:         "defaults",
+			wantInterval: defaultHealthCheckIntervalSeconds,
+			wantTimeout:  defaultHealthCheckTimeoutSeconds,
+		},
+		{
+			name:         "minimum interval",
+			interval:     1,
+			timeout:      5,
+			wantInterval: minHealthCheckIntervalSeconds,
+			wantTimeout:  5,
+		},
+		{
+			name:         "maximum interval and timeout",
+			interval:     999,
+			timeout:      999,
+			wantInterval: maxHealthCheckIntervalSeconds,
+			wantTimeout:  maxHealthCheckTimeoutSeconds,
+		},
+		{
+			name:         "timeout cannot exceed interval",
+			interval:     10,
+			timeout:      30,
+			wantInterval: 10,
+			wantTimeout:  10,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewServiceCache()
+			c.Add(makeApp("uid-bounds", "app", "ns", "app.example.com", &sdapp.LandingPage{
+				Enabled: true,
+				HealthCheck: &sdapp.HealthCheck{
+					Enabled:         true,
+					Path:            "/ready",
+					IntervalSeconds: tt.interval,
+					TimeoutSeconds:  tt.timeout,
+				},
+			}))
+
+			svc := c.Get("uid-bounds")
+			if svc == nil || svc.HealthCheckConfig == nil {
+				t.Fatalf("expected health check config, got %+v", svc)
+			}
+			if got := svc.HealthCheckConfig.IntervalSeconds; got != tt.wantInterval {
+				t.Errorf("IntervalSeconds = %d, want %d", got, tt.wantInterval)
+			}
+			if got := svc.HealthCheckConfig.TimeoutSeconds; got != tt.wantTimeout {
+				t.Errorf("TimeoutSeconds = %d, want %d", got, tt.wantTimeout)
+			}
+		})
+	}
+}
+
+func TestBuildHealthCheckConfig_RejectsInvalidPort(t *testing.T) {
+	c := NewServiceCache()
+	c.Add(makeApp("uid-port", "app", "ns", "app.example.com", &sdapp.LandingPage{
+		Enabled: true,
+		HealthCheck: &sdapp.HealthCheck{
+			Enabled: true,
+			Path:    "/ready",
+			Port:    70000,
+		},
+	}))
+
+	svc := c.Get("uid-port")
+	if svc == nil {
+		t.Fatal("expected service in cache")
+	}
+	if svc.HealthCheckConfig != nil {
+		t.Fatalf("expected invalid port to disable health check, got %+v", svc.HealthCheckConfig)
+	}
+}
+
+func TestBuildHealthCheckConfig_RejectsInvalidServiceDNSName(t *testing.T) {
+	c := NewServiceCache()
+	a := makeApp("uid-service-name", "app", "ns", "app.example.com", &sdapp.LandingPage{
+		Enabled: true,
+		HealthCheck: &sdapp.HealthCheck{
+			Enabled: true,
+			Path:    "/ready",
+		},
+	})
+	a.ServiceName = "bad_name"
+	c.Add(a)
+
+	svc := c.Get("uid-service-name")
+	if svc == nil {
+		t.Fatal("expected service in cache")
+	}
+	if svc.HealthCheckConfig != nil {
+		t.Fatalf("expected invalid service name to disable health check, got %+v", svc.HealthCheckConfig)
+	}
+}
+
+func TestBuildHealthCheckConfig_RejectsInvalidServiceNamespace(t *testing.T) {
+	c := NewServiceCache()
+	a := makeApp("uid-service-namespace", "app", "ns", "app.example.com", &sdapp.LandingPage{
+		Enabled: true,
+		HealthCheck: &sdapp.HealthCheck{
+			Enabled: true,
+			Path:    "/ready",
+		},
+	})
+	a.ServiceNamespace = "bad_namespace"
+	a.HealthCheckCrossNamespaceAllowed = true
+	c.Add(a)
+
+	svc := c.Get("uid-service-namespace")
+	if svc == nil {
+		t.Fatal("expected service in cache")
+	}
+	if svc.HealthCheckConfig != nil {
+		t.Fatalf("expected invalid service namespace to disable health check, got %+v", svc.HealthCheckConfig)
+	}
+}
+
+func TestBuildHealthCheckConfig_RejectsProtectedTargets(t *testing.T) {
+	for _, tt := range []struct {
+		name             string
+		namespace        string
+		serviceName      string
+		servicePort      int
+		crossNamespaceOK bool
+	}{
+		{
+			name:             "system namespace",
+			namespace:        "kube-system",
+			serviceName:      "app-backend",
+			servicePort:      8080,
+			crossNamespaceOK: true,
+		},
+		{
+			name:             "identity namespace",
+			namespace:        "keycloak",
+			serviceName:      "app-backend",
+			servicePort:      8080,
+			crossNamespaceOK: true,
+		},
+		{
+			name:        "database service name",
+			namespace:   "team-a",
+			serviceName: "nebari-redis-master",
+			servicePort: 8080,
+		},
+		{
+			name:        "control-plane service name",
+			namespace:   "team-a",
+			serviceName: "kubernetes",
+			servicePort: 8080,
+		},
+		{
+			name:        "database port",
+			namespace:   "team-a",
+			serviceName: "app-backend",
+			servicePort: 5432,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewServiceCache()
+			a := makeApp("uid-protected", "app", "team-a", "app.example.com", &sdapp.LandingPage{
+				Enabled: true,
+				HealthCheck: &sdapp.HealthCheck{
+					Enabled: true,
+					Path:    "/ready",
+				},
+			})
+			a.ServiceNamespace = tt.namespace
+			a.ServiceName = tt.serviceName
+			a.ServicePort = tt.servicePort
+			a.HealthCheckCrossNamespaceAllowed = tt.crossNamespaceOK
+
+			c.Add(a)
+
+			svc := c.Get("uid-protected")
+			if svc == nil {
+				t.Fatal("expected service in cache")
+			}
+			if svc.HealthCheckConfig != nil {
+				t.Fatalf("expected protected target to disable health check, got %+v", svc.HealthCheckConfig)
+			}
+		})
+	}
+}
+
+func TestBuildHealthCheckConfig_RejectsHealthCheckPortOverride(t *testing.T) {
+	c := NewServiceCache()
+	a := makeApp("uid-port-override", "app", "team-a", "app.example.com", &sdapp.LandingPage{
+		Enabled: true,
+		HealthCheck: &sdapp.HealthCheck{
+			Enabled: true,
+			Path:    "/ready",
+			Port:    9000,
+		},
+	})
+	a.ServiceName = "app-backend"
+	a.ServicePort = 8080
+
+	c.Add(a)
+
+	svc := c.Get("uid-port-override")
+	if svc == nil {
+		t.Fatal("expected service in cache")
+	}
+	if svc.HealthCheckConfig != nil {
+		t.Fatalf("expected healthCheck.port override to disable health check, got %+v", svc.HealthCheckConfig)
+	}
+}
+
+func TestAdd_ResetsHealthWhenConfiguredHealthCheckBecomesInvalid(t *testing.T) {
+	c := NewServiceCache()
+	a := makeApp("uid-reset", "app", "ns", "app.example.com", &sdapp.LandingPage{
+		Enabled: true,
+		HealthCheck: &sdapp.HealthCheck{
+			Enabled: true,
+			Path:    "/ready",
+		},
+	})
+	c.Add(a)
+	now := time.Now()
+	c.UpdateHealth("uid-reset", &HealthStatus{Status: "healthy", LastCheck: &now})
+
+	a.ServiceNamespace = "other-ns"
+	c.Add(a)
+
+	svc := c.Get("uid-reset")
+	if svc == nil {
+		t.Fatal("expected service in cache")
+	}
+	if svc.HealthCheckConfig != nil {
+		t.Fatalf("expected denied health check config, got %+v", svc.HealthCheckConfig)
+	}
+	if svc.Health == nil || svc.Health.Status != "unknown" || svc.Health.LastCheck != nil {
+		t.Fatalf("expected health to reset to unknown, got %+v", svc.Health)
+	}
+}
+
+func TestAdd_ResetsHealthWhenHealthCheckIsRemoved(t *testing.T) {
+	c := NewServiceCache()
+	a := makeApp("uid-remove-health", "app", "ns", "app.example.com", &sdapp.LandingPage{
+		Enabled: true,
+		HealthCheck: &sdapp.HealthCheck{
+			Enabled: true,
+			Path:    "/ready",
+		},
+	})
+	c.Add(a)
+	now := time.Now()
+	c.UpdateHealth("uid-remove-health", &HealthStatus{Status: "healthy", LastCheck: &now})
+
+	a.LandingPage.HealthCheck = nil
+	c.Add(a)
+
+	svc := c.Get("uid-remove-health")
+	if svc == nil {
+		t.Fatal("expected service in cache")
+	}
+	if svc.HealthCheckConfig != nil {
+		t.Fatalf("expected removed health check config, got %+v", svc.HealthCheckConfig)
+	}
+	if svc.Health == nil || svc.Health.Status != "unknown" || svc.Health.LastCheck != nil {
+		t.Fatalf("expected health to reset to unknown, got %+v", svc.Health)
 	}
 }

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -1,9 +1,13 @@
 package health
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -36,27 +40,48 @@ type HealthChecker struct {
 	publisher      Publisher             // optional; may be nil
 	notifPublisher NotificationPublisher // optional; may be nil
 	notifStore     *notifications.Store  // optional; when set, "back online" notifications are posted
-	// running maps UID → (cancel func, current ProbeURL).
-	// The ProbeURL is stored so reconcile can detect config changes and restart
-	// the probe goroutine when a NebariApp's healthCheck spec is updated.
+	probeRequester probeRequester
+	// running maps UID → (cancel func, current config). The config is stored so
+	// reconcile can detect changes and restart the probe goroutine when a
+	// NebariApp's healthCheck spec is updated.
 	mu      sync.Mutex
 	running map[string]runningProbe
 }
 
 type runningProbe struct {
-	cancel   context.CancelFunc
-	probeURL string // the URL this goroutine is currently configured to probe
+	cancel context.CancelFunc
+	config cache.HealthCheckConfig
 }
+
+type probeRequester interface {
+	Probe(ctx context.Context, uid string, cfg *cache.HealthCheckConfig) probeResult
+}
+
+type directProbeRequester struct{}
 
 // NewHealthChecker creates a new health checker.
 // interval is the fallback polling interval used when a service's
 // HealthCheckConfig doesn't specify one.
 func NewHealthChecker(serviceCache *cache.ServiceCache, interval time.Duration) *HealthChecker {
 	return &HealthChecker{
-		cache:    serviceCache,
-		interval: interval,
-		running:  make(map[string]runningProbe),
+		cache:          serviceCache,
+		interval:       interval,
+		probeRequester: directProbeRequester{},
+		running:        make(map[string]runningProbe),
 	}
+}
+
+// SetProbeRunnerURL delegates health probes to a separate probe-runner HTTP
+// service. Keeping the runner in its own pod lets Kubernetes NetworkPolicy give
+// probe traffic a narrower egress policy than the main webapi pod needs for
+// Redis, Keycloak, and Kubernetes API access.
+func (h *HealthChecker) SetProbeRunnerURL(rawURL string) error {
+	requester, err := newRemoteProbeRequester(rawURL)
+	if err != nil {
+		return err
+	}
+	h.probeRequester = requester
+	return nil
 }
 
 // SetPublisher attaches an event publisher that is notified whenever a
@@ -152,24 +177,22 @@ func (h *HealthChecker) reconcile(ctx context.Context) {
 
 		h.mu.Lock()
 		rp, running := h.running[svc.UID]
-		// Restart the goroutine if the probe URL changed (NebariApp was updated).
-		if running && rp.probeURL != svc.HealthCheckConfig.ProbeURL {
-			log.Info("Probe URL changed — restarting probe goroutine",
-				"uid", svc.UID, "old", rp.probeURL, "new", svc.HealthCheckConfig.ProbeURL)
+		// Restart the goroutine if the probe config changed (NebariApp was updated).
+		if running && rp.config != *svc.HealthCheckConfig {
+			log.Info("Probe config changed; restarting probe goroutine",
+				"uid", svc.UID, "oldURL", rp.config.ProbeURL, "newURL", svc.HealthCheckConfig.ProbeURL)
 			rp.cancel()
 			running = false
 			delete(h.running, svc.UID)
 		}
 		if !running {
 			probeCtx, cancel := context.WithCancel(ctx)
-			h.running[svc.UID] = runningProbe{cancel: cancel, probeURL: svc.HealthCheckConfig.ProbeURL}
+			h.running[svc.UID] = runningProbe{cancel: cancel, config: *svc.HealthCheckConfig}
 			log.Info("Starting probe goroutine", "uid", svc.UID, "name", svc.DisplayName, "url", svc.HealthCheckConfig.ProbeURL)
 			go h.probeLoop(probeCtx, svc.UID, svc.HealthCheckConfig)
 		}
 		h.mu.Unlock()
 	}
-
-	log.Info("Reconcile complete", "total", len(services), "checkable", checkable, "goroutines", len(h.running))
 
 	// Stop probes for services that have been removed from the cache.
 	h.mu.Lock()
@@ -179,7 +202,10 @@ func (h *HealthChecker) reconcile(ctx context.Context) {
 			delete(h.running, uid)
 		}
 	}
+	runningCount := len(h.running)
 	h.mu.Unlock()
+
+	log.Info("Reconcile complete", "total", len(services), "checkable", checkable, "goroutines", runningCount)
 }
 
 // stopAll cancels every running probe goroutine.
@@ -206,28 +232,75 @@ func (h *HealthChecker) probeLoop(ctx context.Context, uid string, cfg *cache.He
 
 	log.Info("Probe loop started", "uid", uid, "url", cfg.ProbeURL, "interval", interval, "timeout", timeout)
 
-	client := &http.Client{
-		Timeout: timeout,
-		// Don't follow redirects — a redirect means the service is up but
-		// redirecting (e.g. HTTP→HTTPS). Treat any response as "reachable".
-		CheckRedirect: func(*http.Request, []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
-
 	// Probe immediately, then repeat on interval.
-	h.probe(ctx, uid, cfg.ProbeURL, client)
+	if !h.probeIfCurrent(ctx, uid, cfg) {
+		return
+	}
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ticker.C:
-			h.probe(ctx, uid, cfg.ProbeURL, client)
+			if !h.probeIfCurrent(ctx, uid, cfg) {
+				return
+			}
 		case <-ctx.Done():
 			log.V(1).Info("Probe loop stopped", "uid", uid)
 			return
 		}
+	}
+}
+
+func (directProbeRequester) Probe(ctx context.Context, uid string, cfg *cache.HealthCheckConfig) probeResult {
+	timeout := time.Duration(cfg.TimeoutSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	return performProbeRequest(ctx, uid, cfg.ProbeURL, newProbeHTTPClient(timeout))
+}
+
+func newProbeHTTPClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout: timeout,
+		// Don't follow redirects. A redirect moves the probe to a target the
+		// NebariApp did not declare, so the response is evaluated as-is.
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+func (h *HealthChecker) probeIfCurrent(ctx context.Context, uid string, cfg *cache.HealthCheckConfig) bool {
+	prevStatus := ""
+	var result probeResult
+	if !h.cache.WithCurrentHealthCheck(uid, cfg, func(currentPrevStatus string) {
+		prevStatus = currentPrevStatus
+		result = h.probeRequester.Probe(ctx, uid, cfg)
+	}) {
+		log.Info("Probe config no longer current; stopping probe loop", "uid", uid, "url", cfg.ProbeURL)
+		h.forgetRunningProbe(uid, cfg)
+		return false
+	}
+	if !h.probeConfigCurrent(uid, cfg) {
+		log.Info("Probe config changed while request was in flight; discarding stale result", "uid", uid, "url", cfg.ProbeURL)
+		h.forgetRunningProbe(uid, cfg)
+		return false
+	}
+	h.applyProbeResult(uid, prevStatus, result)
+	return true
+}
+
+func (h *HealthChecker) probeConfigCurrent(uid string, cfg *cache.HealthCheckConfig) bool {
+	return h.cache.HealthCheckConfigCurrent(uid, cfg)
+}
+
+func (h *HealthChecker) forgetRunningProbe(uid string, cfg *cache.HealthCheckConfig) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if rp, ok := h.running[uid]; ok && rp.config == *cfg {
+		rp.cancel()
+		delete(h.running, uid)
 	}
 }
 
@@ -241,19 +314,27 @@ func (h *HealthChecker) probe(ctx context.Context, uid, probeURL string, client 
 		prevStatus = svc.Health.Status
 	}
 
+	h.applyProbeResult(uid, prevStatus, performProbeRequest(ctx, uid, probeURL, client))
+}
+
+type probeResult struct {
+	status    string
+	message   string
+	checkedAt time.Time
+}
+
+func performProbeRequest(ctx context.Context, uid, probeURL string, client *http.Client) probeResult {
+	now := time.Now()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, probeURL, nil)
 	if err != nil {
 		log.Info("Health probe request error", "uid", uid, "url", probeURL, "err", err)
-		h.setStatus(uid, "unknown", fmt.Sprintf("failed to build request: %v", err))
-		return
+		return probeResult{status: "unknown", checkedAt: now, message: fmt.Sprintf("failed to build request: %v", err)}
 	}
 
-	now := time.Now()
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Info("Health probe failed", "uid", uid, "url", probeURL, "err", err)
-		h.setStatus(uid, "unhealthy", fmt.Sprintf("probe error: %v", err))
-		return
+		return probeResult{status: "unhealthy", checkedAt: now, message: fmt.Sprintf("probe error: %v", err)}
 	}
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {
@@ -261,33 +342,115 @@ func (h *HealthChecker) probe(ctx context.Context, uid, probeURL string, client 
 		}
 	}()
 
-	if resp.StatusCode >= 200 && resp.StatusCode < 400 {
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		log.Info("Health probe ok", "uid", uid, "url", probeURL, "status", resp.StatusCode)
-		h.cache.UpdateHealth(uid, &cache.HealthStatus{
-			Status:    "healthy",
-			LastCheck: &now,
-			Message:   fmt.Sprintf("HTTP %d", resp.StatusCode),
-		})
-		// Post a "back online" notification when recovering from unhealthy.
-		if prevStatus == "unhealthy" {
-			h.postRecoveryNotif(uid)
-		}
-	} else {
-		log.Info("Health probe unhealthy", "uid", uid, "url", probeURL, "status", resp.StatusCode)
-		h.setStatus(uid, "unhealthy", fmt.Sprintf("HTTP %d", resp.StatusCode))
+		return probeResult{status: "healthy", checkedAt: now, message: fmt.Sprintf("HTTP %d", resp.StatusCode)}
 	}
-
-	h.publishIfChanged(uid)
+	log.Info("Health probe unhealthy", "uid", uid, "url", probeURL, "status", resp.StatusCode)
+	return probeResult{status: "unhealthy", checkedAt: now, message: fmt.Sprintf("HTTP %d", resp.StatusCode)}
 }
 
-// setStatus writes a HealthStatus with the given status string and message.
-func (h *HealthChecker) setStatus(uid, status, message string) {
+type remoteProbeRequester struct {
+	endpoint string
+	client   *http.Client
+}
+
+type remoteProbeRequest struct {
+	ProbeURL       string `json:"probeUrl"`
+	TimeoutSeconds int    `json:"timeoutSeconds"`
+}
+
+type remoteProbeResponse struct {
+	Status    string    `json:"status"`
+	Message   string    `json:"message"`
+	CheckedAt time.Time `json:"checkedAt"`
+}
+
+func newRemoteProbeRequester(rawURL string) (*remoteProbeRequester, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid health probe runner URL: %w", err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, fmt.Errorf("health probe runner URL must use http or https")
+	}
+	if parsed.Host == "" {
+		return nil, fmt.Errorf("health probe runner URL must include a host")
+	}
+	return &remoteProbeRequester{
+		endpoint: parsed.ResolveReference(&url.URL{Path: "/probe"}).String(),
+		client: &http.Client{
+			Timeout: 35 * time.Second,
+		},
+	}, nil
+}
+
+func (r *remoteProbeRequester) Probe(ctx context.Context, uid string, cfg *cache.HealthCheckConfig) probeResult {
 	now := time.Now()
-	h.cache.UpdateHealth(uid, &cache.HealthStatus{
-		Status:    status,
-		LastCheck: &now,
-		Message:   message,
+	payload, err := json.Marshal(remoteProbeRequest{
+		ProbeURL:       cfg.ProbeURL,
+		TimeoutSeconds: cfg.TimeoutSeconds,
 	})
+	if err != nil {
+		return probeResult{status: "unknown", checkedAt: now, message: fmt.Sprintf("failed to build probe request: %v", err)}
+	}
+
+	timeout := time.Duration(cfg.TimeoutSeconds)*time.Second + time.Second
+	if timeout <= time.Second {
+		timeout = 6 * time.Second
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodPost, r.endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return probeResult{status: "unknown", checkedAt: now, message: fmt.Sprintf("failed to build probe runner request: %v", err)}
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return probeResult{status: "unhealthy", checkedAt: now, message: fmt.Sprintf("probe runner error: %v", err)}
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.V(1).Info("Health probe runner: failed to close response body", "uid", uid, "err", closeErr)
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return probeResult{
+			status:    "unhealthy",
+			checkedAt: now,
+			message:   fmt.Sprintf("probe runner HTTP %d: %s", resp.StatusCode, string(bytes.TrimSpace(body))),
+		}
+	}
+
+	var out remoteProbeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return probeResult{status: "unknown", checkedAt: now, message: fmt.Sprintf("failed to decode probe runner response: %v", err)}
+	}
+	if out.CheckedAt.IsZero() {
+		out.CheckedAt = now
+	}
+	if out.Status == "" {
+		out.Status = "unknown"
+	}
+	return probeResult{status: out.Status, checkedAt: out.CheckedAt, message: out.Message}
+}
+
+func (h *HealthChecker) applyProbeResult(uid, prevStatus string, result probeResult) {
+	checkedAt := result.checkedAt
+	h.cache.UpdateHealth(uid, &cache.HealthStatus{
+		Status:    result.status,
+		LastCheck: &checkedAt,
+		Message:   result.message,
+	})
+	// Post a "back online" notification when recovering from unhealthy.
+	if result.status == "healthy" && prevStatus == "unhealthy" {
+		h.postRecoveryNotif(uid)
+	}
 	h.publishIfChanged(uid)
 }
 

--- a/internal/health/checker_test.go
+++ b/internal/health/checker_test.go
@@ -1,0 +1,132 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	sdapp "github.com/nebari-dev/nebari-landing/internal/app"
+	"github.com/nebari-dev/nebari-landing/internal/cache"
+)
+
+func TestProbe_DeniesRedirect(t *testing.T) {
+	finalHit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/redirect":
+			http.Redirect(w, r, "/final", http.StatusFound)
+		case "/final":
+			finalHit = true
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	serviceCache := cache.NewServiceCache()
+	serviceCache.Add(&sdapp.App{
+		UID:         "uid-redirect",
+		Name:        "app",
+		Namespace:   "ns",
+		Hostname:    "app.example.com",
+		TLSEnabled:  true,
+		LandingPage: &sdapp.LandingPage{Enabled: true},
+	})
+
+	checker := NewHealthChecker(serviceCache, time.Second)
+	checker.probe(context.Background(), "uid-redirect", server.URL+"/redirect", newProbeHTTPClient(time.Second))
+
+	if finalHit {
+		t.Fatal("expected health probe not to follow redirect")
+	}
+	svc := serviceCache.Get("uid-redirect")
+	if svc == nil || svc.Health == nil {
+		t.Fatalf("expected health status, got %+v", svc)
+	}
+	if svc.Health.Status != "unhealthy" {
+		t.Fatalf("health status = %q, want unhealthy", svc.Health.Status)
+	}
+	if svc.Health.Message != "HTTP 302" {
+		t.Fatalf("health message = %q, want HTTP 302", svc.Health.Message)
+	}
+}
+
+func TestProbeIfCurrentSkipsRevokedConfig(t *testing.T) {
+	serviceCache := cache.NewServiceCache()
+	app := &sdapp.App{
+		UID:         "uid-revoked",
+		Name:        "app",
+		Namespace:   "ns",
+		Hostname:    "app.example.com",
+		TLSEnabled:  true,
+		ServiceName: "app-backend",
+		ServicePort: 8080,
+		LandingPage: &sdapp.LandingPage{Enabled: true, HealthCheck: &sdapp.HealthCheck{Enabled: true, Path: "/ready"}},
+	}
+	serviceCache.Add(app)
+	svc := serviceCache.Get("uid-revoked")
+	if svc == nil || svc.HealthCheckConfig == nil {
+		t.Fatalf("expected initial health check config, got %+v", svc)
+	}
+	cfg := *svc.HealthCheckConfig
+
+	app.LandingPage.HealthCheck = nil
+	serviceCache.Add(app)
+
+	requester := &countingProbeRequester{}
+	checker := NewHealthChecker(serviceCache, time.Second)
+	checker.probeRequester = requester
+	checker.running["uid-revoked"] = runningProbe{cancel: func() {}, config: cfg}
+
+	if checker.probeIfCurrent(context.Background(), "uid-revoked", &cfg) {
+		t.Fatal("expected revoked config to stop the probe loop")
+	}
+	if requester.called {
+		t.Fatal("expected revoked config not to issue an HTTP request")
+	}
+	if _, ok := checker.running["uid-revoked"]; ok {
+		t.Fatal("expected stale running probe bookkeeping to be cleared")
+	}
+}
+
+func TestProbeRunnerRejectsProtectedTargets(t *testing.T) {
+	for _, rawURL := range []string{
+		"http://kubernetes.default:443/healthz",
+		"http://redis.team-a:6379/",
+		"http://keycloak.keycloak:8080/health",
+		"http://app.kube-system:8080/health",
+		"http://10.96.0.1:443/healthz",
+		"http://app.team-a.example.com:8080/health",
+	} {
+		t.Run(rawURL, func(t *testing.T) {
+			if err := validateProbeRunnerTarget(rawURL); err == nil {
+				t.Fatal("expected protected target to be rejected")
+			}
+		})
+	}
+}
+
+func TestProbeRunnerAllowsServiceNamespaceTarget(t *testing.T) {
+	if err := validateProbeRunnerTarget("http://app-backend.team-a:8080/ready"); err != nil {
+		t.Fatalf("expected service.namespace target to be allowed, got %v", err)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type countingProbeRequester struct {
+	called bool
+}
+
+func (r *countingProbeRequester) Probe(context.Context, string, *cache.HealthCheckConfig) probeResult {
+	r.called = true
+	return probeResult{status: "healthy", checkedAt: time.Now(), message: fmt.Sprintf("called=%v", r.called)}
+}

--- a/internal/health/probe_runner.go
+++ b/internal/health/probe_runner.go
@@ -1,0 +1,91 @@
+package health
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nebari-dev/nebari-landing/internal/cache"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+const maxProbeRunnerBodyBytes = 4096
+
+// NewProbeRunnerHandler returns the HTTP handler used by the isolated
+// health-probe runner deployment. It has no Kubernetes, Redis, or Keycloak
+// clients; its pod-level NetworkPolicy is the enforcement point for health
+// target egress.
+func NewProbeRunnerHandler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/probe", handleProbeRunnerRequest)
+	return mux
+}
+
+func handleProbeRunnerRequest(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req remoteProbeRequest
+	body := http.MaxBytesReader(w, r.Body, maxProbeRunnerBodyBytes)
+	defer body.Close()
+	if err := json.NewDecoder(body).Decode(&req); err != nil {
+		http.Error(w, "invalid probe request", http.StatusBadRequest)
+		return
+	}
+	if err := validateProbeRunnerTarget(req.ProbeURL); err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+
+	timeout := time.Duration(req.TimeoutSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	result := performProbeRequest(r.Context(), "", req.ProbeURL, newProbeHTTPClient(timeout))
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(remoteProbeResponse{
+		Status:    result.status,
+		Message:   result.message,
+		CheckedAt: result.checkedAt,
+	}); err != nil {
+		log.Error(err, "Failed to encode probe runner response")
+	}
+}
+
+func validateProbeRunnerTarget(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid probe URL")
+	}
+	if parsed.Scheme != "http" || parsed.Host == "" {
+		return fmt.Errorf("probe URL must be an in-cluster HTTP service URL")
+	}
+	port, err := strconv.Atoi(parsed.Port())
+	if err != nil {
+		return fmt.Errorf("probe URL must include a numeric port")
+	}
+	hostParts := strings.Split(parsed.Hostname(), ".")
+	if len(hostParts) != 2 && !(len(hostParts) >= 4 && hostParts[2] == "svc") {
+		return fmt.Errorf("probe URL must use service.namespace DNS")
+	}
+	serviceName := hostParts[0]
+	namespace := hostParts[1]
+	if len(validation.IsDNS1035Label(serviceName)) != 0 || len(validation.IsDNS1123Label(namespace)) != 0 {
+		return fmt.Errorf("probe URL must use valid service and namespace labels")
+	}
+	if cache.HealthCheckTargetProtected(namespace, serviceName, port) {
+		return fmt.Errorf("probe target is protected")
+	}
+	return nil
+}

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -28,6 +28,18 @@ var nebariAppGVK = schema.GroupVersionKind{
 	Kind:    "NebariApp",
 }
 
+var referenceGrantGVK = schema.GroupVersionKind{
+	Group:   "gateway.networking.k8s.io",
+	Version: "v1beta1",
+	Kind:    "ReferenceGrant",
+}
+
+var referenceGrantListGVK = schema.GroupVersionKind{
+	Group:   referenceGrantGVK.Group,
+	Version: referenceGrantGVK.Version,
+	Kind:    referenceGrantGVK.Kind + "List",
+}
+
 var log = ctrl.Log.WithName("watcher")
 
 // Publisher receives service change events. *websocket.Hub satisfies this interface.
@@ -183,7 +195,7 @@ func (w *NebariAppWatcher) syncInitial(ctx context.Context) error {
 				"namespace", u.GetNamespace(),
 				"displayName", displayName,
 			)
-			w.cache.Add(toApp(u))
+			w.cache.Add(w.toApp(ctx, u))
 		}
 	}
 
@@ -197,16 +209,77 @@ func (w *NebariAppWatcher) watch(ctx context.Context) error {
 	}
 
 	_, err = informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    w.onAdd,
-		UpdateFunc: w.onUpdate,
+		AddFunc: func(obj interface{}) {
+			w.onAdd(ctx, obj)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			w.onUpdate(ctx, oldObj, newObj)
+		},
 		DeleteFunc: w.onDelete,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to add event handler: %w", err)
 	}
 
+	if err := w.watchReferenceGrants(ctx); err != nil {
+		log.Info("ReferenceGrant watch unavailable; cross-namespace health-check consent will refresh on NebariApp updates",
+			"err", err)
+	}
+
 	<-ctx.Done()
 	return nil
+}
+
+func (w *NebariAppWatcher) watchReferenceGrants(ctx context.Context) error {
+	informer, err := w.kubeCache.GetInformerForKind(ctx, referenceGrantGVK)
+	if err != nil {
+		return fmt.Errorf("failed to get ReferenceGrant informer: %w", err)
+	}
+	_, err = informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(interface{}) {
+			w.resyncCrossNamespaceApps(ctx)
+		},
+		UpdateFunc: func(interface{}, interface{}) {
+			w.resyncCrossNamespaceApps(ctx)
+		},
+		DeleteFunc: func(interface{}) {
+			w.resyncCrossNamespaceApps(ctx)
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to add ReferenceGrant event handler: %w", err)
+	}
+	return nil
+}
+
+func (w *NebariAppWatcher) resyncCrossNamespaceApps(ctx context.Context) {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   nebariAppGVK.Group,
+		Version: nebariAppGVK.Version,
+		Kind:    nebariAppGVK.Kind + "List",
+	})
+	if err := w.client.List(ctx, list); err != nil {
+		log.Error(err, "Failed to resync NebariApps after ReferenceGrant change")
+		return
+	}
+
+	for i := range list.Items {
+		u := &list.Items[i]
+		if !lpEnabled(u) {
+			continue
+		}
+		serviceNamespace, _, _ := unstructured.NestedString(u.Object, "spec", "service", "namespace")
+		if serviceNamespace == "" || serviceNamespace == u.GetNamespace() {
+			continue
+		}
+		w.cache.Add(w.toApp(ctx, u))
+		if w.publisher != nil {
+			if svc := w.cache.Get(string(u.GetUID())); svc != nil {
+				w.publisher.Publish("modified", svc)
+			}
+		}
+	}
 }
 
 // asUnstructured casts obj to *unstructured.Unstructured, handling tombstones.
@@ -224,7 +297,7 @@ func asUnstructured(obj interface{}) (*unstructured.Unstructured, bool) {
 	return u, ok
 }
 
-func (w *NebariAppWatcher) onAdd(obj interface{}) {
+func (w *NebariAppWatcher) onAdd(ctx context.Context, obj interface{}) {
 	u, ok := asUnstructured(obj)
 	if !ok {
 		log.Error(nil, "Failed to cast object to Unstructured", "type", fmt.Sprintf("%T", obj))
@@ -238,7 +311,7 @@ func (w *NebariAppWatcher) onAdd(obj interface{}) {
 			"namespace", u.GetNamespace(),
 			"displayName", displayName,
 		)
-		w.cache.Add(toApp(u))
+		w.cache.Add(w.toApp(ctx, u))
 		uid := string(u.GetUID())
 		if w.publisher != nil {
 			w.publisher.Publish("added", w.cache.Get(uid))
@@ -263,7 +336,7 @@ func (w *NebariAppWatcher) onAdd(obj interface{}) {
 	}
 }
 
-func (w *NebariAppWatcher) onUpdate(_, newObj interface{}) {
+func (w *NebariAppWatcher) onUpdate(ctx context.Context, _ interface{}, newObj interface{}) {
 	u, ok := asUnstructured(newObj)
 	if !ok {
 		log.Error(nil, "Failed to cast object to Unstructured", "type", fmt.Sprintf("%T", newObj))
@@ -279,7 +352,7 @@ func (w *NebariAppWatcher) onUpdate(_, newObj interface{}) {
 			"namespace", u.GetNamespace(),
 			"displayName", displayName,
 		)
-		w.cache.Add(toApp(u))
+		w.cache.Add(w.toApp(ctx, u))
 		if w.publisher != nil {
 			w.publisher.Publish("modified", w.cache.Get(uid))
 		}
@@ -351,6 +424,89 @@ func (w *NebariAppWatcher) WaitForCacheSync(ctx context.Context) bool {
 func lpEnabled(u *unstructured.Unstructured) bool {
 	enabled, _, _ := unstructured.NestedBool(u.Object, "spec", "landingPage", "enabled")
 	return enabled
+}
+
+func (w *NebariAppWatcher) toApp(ctx context.Context, u *unstructured.Unstructured) *sdapp.App {
+	a := toApp(u)
+	if a.ServiceNamespace != "" && a.ServiceNamespace != a.Namespace {
+		a.HealthCheckCrossNamespaceAllowed = w.crossNamespaceHealthCheckAllowed(ctx, a)
+	}
+	return a
+}
+
+func (w *NebariAppWatcher) crossNamespaceHealthCheckAllowed(ctx context.Context, a *sdapp.App) bool {
+	serviceName := a.ServiceName
+	if serviceName == "" {
+		serviceName = a.Name
+	}
+
+	grants := &unstructured.UnstructuredList{}
+	grants.SetGroupVersionKind(referenceGrantListGVK)
+	if err := w.client.List(ctx, grants, client.InNamespace(a.ServiceNamespace)); err != nil {
+		log.Info("Cross-namespace health check denied; unable to list ReferenceGrants",
+			"name", a.Name,
+			"namespace", a.Namespace,
+			"targetNamespace", a.ServiceNamespace,
+			"targetService", serviceName,
+			"err", err,
+		)
+		return false
+	}
+	for i := range grants.Items {
+		if referenceGrantAllows(&grants.Items[i], a.Namespace, serviceName) {
+			return true
+		}
+	}
+	log.Info("Cross-namespace health check denied; no ReferenceGrant permits target Service",
+		"name", a.Name,
+		"namespace", a.Namespace,
+		"targetNamespace", a.ServiceNamespace,
+		"targetService", serviceName,
+	)
+	return false
+}
+
+func referenceGrantAllows(grant *unstructured.Unstructured, sourceNamespace, serviceName string) bool {
+	from, found, err := unstructured.NestedSlice(grant.Object, "spec", "from")
+	if err != nil || !found {
+		return false
+	}
+	to, found, err := unstructured.NestedSlice(grant.Object, "spec", "to")
+	if err != nil || !found {
+		return false
+	}
+
+	fromAllowed := false
+	for _, item := range from {
+		entry, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		group, _, _ := unstructured.NestedString(entry, "group")
+		kind, _, _ := unstructured.NestedString(entry, "kind")
+		namespace, _, _ := unstructured.NestedString(entry, "namespace")
+		if group == nebariAppGVK.Group && kind == nebariAppGVK.Kind && namespace == sourceNamespace {
+			fromAllowed = true
+			break
+		}
+	}
+	if !fromAllowed {
+		return false
+	}
+
+	for _, item := range to {
+		entry, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		group, _, _ := unstructured.NestedString(entry, "group")
+		kind, _, _ := unstructured.NestedString(entry, "kind")
+		name, _, _ := unstructured.NestedString(entry, "name")
+		if group == "" && kind == "Service" && (name == "" || name == serviceName) {
+			return true
+		}
+	}
+	return false
 }
 
 // toApp converts an unstructured NebariApp object to the internal sdapp.App

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -1,0 +1,157 @@
+package watcher
+
+import (
+	"context"
+	"testing"
+
+	landingcache "github.com/nebari-dev/nebari-landing/internal/cache"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestWatcherToAppAllowsCrossNamespaceHealthCheckWithReferenceGrant(t *testing.T) {
+	w := newTestWatcher(referenceGrant("team-a", "shared-api"))
+	app := w.toApp(context.Background(), nebariApp("uid-allow", "app", "team-a", "shared-api", "platform"))
+
+	if !app.HealthCheckCrossNamespaceAllowed {
+		t.Fatal("expected ReferenceGrant to allow cross-namespace health check")
+	}
+
+	c := landingcache.NewServiceCache()
+	c.Add(app)
+	svc := c.Get("uid-allow")
+	if svc == nil || svc.HealthCheckConfig == nil {
+		t.Fatalf("expected cross-namespace health check config, got %+v", svc)
+	}
+	if got, want := svc.HealthCheckConfig.ProbeURL, "http://shared-api.platform:8080/ready"; got != want {
+		t.Fatalf("ProbeURL = %q, want %q", got, want)
+	}
+}
+
+func TestWatcherToAppDeniesCrossNamespaceHealthCheckWithoutReferenceGrant(t *testing.T) {
+	w := newTestWatcher()
+	app := w.toApp(context.Background(), nebariApp("uid-deny", "app", "team-a", "shared-api", "platform"))
+
+	if app.HealthCheckCrossNamespaceAllowed {
+		t.Fatal("expected missing ReferenceGrant to deny cross-namespace health check")
+	}
+
+	c := landingcache.NewServiceCache()
+	c.Add(app)
+	svc := c.Get("uid-deny")
+	if svc == nil {
+		t.Fatal("expected service to remain visible")
+	}
+	if svc.HealthCheckConfig != nil {
+		t.Fatalf("expected denied cross-namespace health check config, got %+v", svc.HealthCheckConfig)
+	}
+}
+
+func TestReferenceGrantAllowsSpecificService(t *testing.T) {
+	grant := referenceGrant("team-a", "shared-api")
+
+	if !referenceGrantAllows(grant, "team-a", "shared-api") {
+		t.Fatal("expected ReferenceGrant to allow matching source namespace and service")
+	}
+}
+
+func TestReferenceGrantAllowsAllServicesWhenNameOmitted(t *testing.T) {
+	grant := referenceGrant("team-a", "")
+
+	if !referenceGrantAllows(grant, "team-a", "shared-api") {
+		t.Fatal("expected unnamed ReferenceGrant target to allow any Service name")
+	}
+}
+
+func TestReferenceGrantRejectsMismatches(t *testing.T) {
+	for _, tt := range []struct {
+		name            string
+		sourceNamespace string
+		serviceName     string
+	}{
+		{name: "source namespace", sourceNamespace: "team-b", serviceName: "shared-api"},
+		{name: "service name", sourceNamespace: "team-a", serviceName: "other-api"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if referenceGrantAllows(referenceGrant("team-a", "shared-api"), tt.sourceNamespace, tt.serviceName) {
+				t.Fatal("expected ReferenceGrant mismatch to be rejected")
+			}
+		})
+	}
+}
+
+func newTestWatcher(objects ...*unstructured.Unstructured) *NebariAppWatcher {
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(referenceGrantGVK, &unstructured.Unstructured{})
+	scheme.AddKnownTypeWithName(referenceGrantListGVK, &unstructured.UnstructuredList{})
+
+	runtimeObjects := make([]runtime.Object, 0, len(objects))
+	for _, obj := range objects {
+		runtimeObjects = append(runtimeObjects, obj)
+	}
+
+	return &NebariAppWatcher{
+		client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithRuntimeObjects(runtimeObjects...).
+			Build(),
+	}
+}
+
+func nebariApp(uid, name, namespace, serviceName, serviceNamespace string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "reconcilers.nebari.dev/v1",
+		"kind":       "NebariApp",
+		"metadata": map[string]interface{}{
+			"name":      name,
+			"namespace": namespace,
+			"uid":       uid,
+		},
+		"spec": map[string]interface{}{
+			"hostname": name + ".example.com",
+			"service": map[string]interface{}{
+				"name":      serviceName,
+				"namespace": serviceNamespace,
+				"port":      int64(8080),
+			},
+			"landingPage": map[string]interface{}{
+				"enabled":     true,
+				"displayName": name,
+				"healthCheck": map[string]interface{}{
+					"enabled": true,
+					"path":    "/ready",
+				},
+			},
+		},
+	}}
+}
+
+func referenceGrant(sourceNamespace, serviceName string) *unstructured.Unstructured {
+	to := map[string]interface{}{
+		"group": "",
+		"kind":  "Service",
+	}
+	if serviceName != "" {
+		to["name"] = serviceName
+	}
+
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "gateway.networking.k8s.io/v1beta1",
+		"kind":       "ReferenceGrant",
+		"metadata": map[string]interface{}{
+			"name":      "allow-health-check",
+			"namespace": "platform",
+		},
+		"spec": map[string]interface{}{
+			"from": []interface{}{
+				map[string]interface{}{
+					"group":     nebariAppGVK.Group,
+					"kind":      nebariAppGVK.Kind,
+					"namespace": sourceNamespace,
+				},
+			},
+			"to": []interface{}{to},
+		},
+	}}
+}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

Closes #159 
## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

This PR hardens `NebariApp` health checks by validating `service`, `namespace`, `port`, `path`, `timeout`, and `interval` settings before probes are accepted. It requires Gateway API `ReferenceGrant` consent for cross-namespace health checks, denies protected namespaces, sensitive services, metadata/control-plane/database/identity ports, and blocks HTTP redirects. Health probes now run through a separate health-prober deployment with its own service, restricted permissions, and NetworkPolicies so the `webapi` cannot directly egress to arbitrary health targets. Tests were added for validation rules, `ReferenceGrant` consent, protected target rejection, redirect handling, stale probe handling, and Helm resource/network policy rendering.